### PR TITLE
Banner inside scrollable area so it does not get fixed on top

### DIFF
--- a/wondrous-app/components/Common/Layout/App/index.tsx
+++ b/wondrous-app/components/Common/Layout/App/index.tsx
@@ -27,7 +27,6 @@ const AppLayout = ({ banner, children }) => {
 	const [minimized, setMinimized] = useState(false)
 	return (
 		<>
-			{banner}
 			<Header />
 			<SideBarContext.Provider
 				value={{
@@ -41,6 +40,7 @@ const AppLayout = ({ banner, children }) => {
 						paddingLeft: minimized ? 0 : SIDEBAR_WIDTH,
 					}}
 				>
+					{banner}
 					<Container>{children}</Container>
 				</Main>
 			</SideBarContext.Provider>


### PR DESCRIPTION
Background image (banner) needs to flow up with the content. Current set leaves it fixed as its not bound to the scroll area. Moved it to the scroll area so it flows up when user scrolls the page.