### PR TITLE
To remove the scrollbar on the sidebar

### DIFF
--- a/wondrous-app/components/SideBar/styles.tsx
+++ b/wondrous-app/components/SideBar/styles.tsx
@@ -20,7 +20,6 @@ export const DrawerComponent = styled(Drawer)`
 `
 
 export const DrawerContainer = styled.div`
-	min-height: 740px;
 	width: ${SIDEBAR_WIDTH};
 	display: flex;
 	flex-grow: 1;


### PR DESCRIPTION
Problem: On some screen/zoom sizes, a scrollbar appears on the sidebar.

Before

<img width="96" alt="sidebar-before" src="https://user-images.githubusercontent.com/8164667/150659994-2522646d-66bd-4c4f-bae9-4266b5ba94f5.png">

After

<img width="97" alt="sidebar-after" src="https://user-images.githubusercontent.com/8164667/150659995-777409ad-1aae-4452-919d-f3b857c954a2.png">

