### PR TITLE
Bugfix: Proper pod vs. contributor DAO module loading

### DIFF
--- a/wondrous-app/components/organization/wrapper/wrapper.tsx
+++ b/wondrous-app/components/organization/wrapper/wrapper.tsx
@@ -125,6 +125,8 @@ const Wrapper = (props) => {
         open={open && (showUsers || showPods)}
         handleClose={() => {
           document.body.setAttribute('style', '');
+          setShowPods(false);
+          setShowUsers(false);
           setOpen(false);
         }}
         showUsers={showUsers}

--- a/wondrous-app/components/profile/modals/index.tsx
+++ b/wondrous-app/components/profile/modals/index.tsx
@@ -127,7 +127,11 @@ export const MoreInfoModal = (props) => {
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [orgId, podId, displayPods, displayUsers, showUsers, showPods]);
   return (
-    <Modal open={open} onClose={handleClose}>
+    <Modal open={open} onClose={() => {
+      handleClose();
+      setDisplayUsers(false);
+      setDisplayPods(false);
+    }}>
       <TaskModal>
         <Title>{name}</Title>
         <TabContainer>


### PR DESCRIPTION
Proper pod vs. contributor DAO module loading

When I select contributors or pods on a DAO page, the first time it properly loads the module. For example, if I click pods, it shows pods. However, if I exit out, then click contributors, it will load the pod module. Inversely, If I refresh the page and select contributors it will work. Then if I exit out and select pods, it will load contributors first.

## Task
https://wondrous-app-git-staging-wonderverse.vercel.app/pod/46359226037043204/boards?task=46369101146226736