### PR TITLE
fix: Role customization locks up

### DIFF
--- a/wondrous-app/components/Settings/Roles/index.tsx
+++ b/wondrous-app/components/Settings/Roles/index.tsx
@@ -84,6 +84,14 @@ const Roles = ({
     setNewRolePermissions(permissions);
   }
 
+  const handleRoleNameChange = (e) => {
+    const roleName = e.target.value;
+    setNewRoleName(roleName);
+    if (!roleName) {
+      setNewRolePermissionsExpanded(false);
+    }
+  };
+
   return (
     <SettingsWrapper>
       <Snackbar
@@ -105,7 +113,7 @@ const Roles = ({
             <LabelBlock>Create a new role</LabelBlock>
 
             <CreateRole>
-              <RoleNameInput value={newRoleName} onChange={(e) => setNewRoleName(e.target.value)} />
+              <RoleNameInput value={newRoleName} onChange={handleRoleNameChange} />
               <CreateRoleButton onClick={handleCreateNewRoleClick} disabled={!newRoleName} highlighted={!!newRoleName}>
                 Create role
               </CreateRoleButton>

--- a/wondrous-app/components/Settings/Roles/styles.tsx
+++ b/wondrous-app/components/Settings/Roles/styles.tsx
@@ -8,7 +8,6 @@ import { Button } from '../../Common/button';
 import { Red800 } from '../../../theme/colors';
 
 export const RolesContainer = styled.div`
-  height: 100vh;
   width: 100%;
   max-width: 765px;
 `;


### PR DESCRIPTION
Bug ticket: https://app.wonderverse.xyz/dashboard?task=50718333122642363&view=grid

**Automatically close and disable the permissions when the input for new role is empty**

https://user-images.githubusercontent.com/8164667/158524249-f4f212d2-9191-430c-8340-c8cd254a9a42.mp4

**Fix for layout issue**

https://user-images.githubusercontent.com/8164667/158495878-00710a7c-7dba-461c-94d0-1c1df5c1aa88.mp4
