### PR TITLE
fix: disappearing task cards

### DIFF
--- a/wondrous-app/components/Common/KanbanBoard/kanbanBoard.tsx
+++ b/wondrous-app/components/Common/KanbanBoard/kanbanBoard.tsx
@@ -189,7 +189,11 @@ const KanbanBoard = (props) => {
   }, [router?.query?.task, router?.query?.taskProposal, orgBoard || userBoard || podBoard]);
 
   const onDragEnd = (result) => {
-    moveCard(result?.draggableId, result?.destination?.droppableId, result?.destination?.index);
+    try {
+      moveCard(result.draggableId, result.destination.droppableId, result.destination.index);
+    } catch {
+      console.error('The card was dropped outside the context of DragDropContext.');
+    }
   };
 
   return (


### PR DESCRIPTION
Bug ticket: https://app.wonderverse.xyz/dashboard?task=50717712054223289&view=grid

Defect: When dropped outside the context, a card doesn't have the incomplete data to properly move a card.
Fix: Make no changes when the card is dropped outside the context.

This is also tested in user board, and pod board.

https://user-images.githubusercontent.com/8164667/158530467-d42f71e9-0297-43c2-b8e2-2e5c20084601.mp4

