### PR TITLE
fix: navigating to a task via link is not working

### DIFF
--- a/wondrous-app/components/Common/Boards/index.tsx
+++ b/wondrous-app/components/Common/Boards/index.tsx
@@ -41,19 +41,13 @@ const Boards = (props: Props) => {
   const { columns, onLoadMore, hasMore, filterSchema, onSearch, onFilterChange, isAdmin } = props;
   const router = useRouter();
   const orgBoard = useOrgBoard();
-  const [view, setView] = useState(null);
   const [totalCount, setTotalCount] = useState(0);
   const [searchResults, setSearchResults] = useState({});
   const { search: searchQuery } = router.query;
   const selectMembershipHook = useSelectMembership();
   const { boardType } = router.query;
   const selectMembershipRequests = selectMembershipHook?.selectMembershipRequests;
-  useEffect(() => {
-    if (router.isReady) {
-      setView((router.query.view || ViewType.Grid) as ViewType);
-    }
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, []);
+  const view = router.query.view ?? ViewType.Grid;
 
   useEffect(() => {
     if (!searchQuery) {


### PR DESCRIPTION
Bug ticket: https://app.wonderverse.xyz/dashboard?task=50921042199183840&view=grid

Defect: The TaskViewModal do not open because the KanbanBoard component is not mounted.
Fix: Get the view from the router.query so the KanbanBoard component will be mounted, which in turn will allow the TaskViewModal to be loaded.

https://user-images.githubusercontent.com/8164667/158747165-e3b78473-5bba-487f-9b3e-670005dd4393.mp4


