### PR TITLE
fix: Archived tasks should disappear from board

### DIFF
--- a/wondrous-app/components/Common/Task/modal.tsx
+++ b/wondrous-app/components/Common/Task/modal.tsx
@@ -806,16 +806,14 @@ export const TaskViewModal = (props: ITaskListModalProps) => {
   });
 
   const [updateTaskStatusMutation, { data: updateTaskStatusMutationData }] = useMutation(UPDATE_TASK_STATUS, {
-    refetchQueries: () => [
-      {
-        query: GET_TASK_BY_ID,
-        variables: {
-          taskId: fetchedTask?.id,
-        },
-      },
-      'getPerStatusTaskCountForOrgBoard',
+    refetchQueries: [
+      'getTaskById',
       'getUserTaskBoardTasks',
       'getPerStatusTaskCountForUserBoard',
+      'getOrgTaskBoardTasks',
+      'getPerStatusTaskCountForOrgBoard',
+      'getPodTaskBoardTasks',
+      'getPerStatusTaskCountForPodBoard',
     ],
     onError: () => {
       console.error('Something went wrong.');


### PR DESCRIPTION
task: https://app.wonderverse.xyz/pod/50256999103856680/boards?task=51441109244576382&view=grid

defect: When the user is in pod board and the user archive the task while in task view modal, the pod board is not updated.
fix: Include the pod board in the refetchQueries of task status mutation

**Defect before fixing**

https://user-images.githubusercontent.com/8164667/161709703-fdda0ca0-c0e1-46b3-adf8-b023c2078b28.mp4

**Fixed**

https://user-images.githubusercontent.com/8164667/161709715-1d7e4655-1f2a-4b24-a43b-2d746d2b746c.mp4


