### PR TITLE
feat: After archiving, close the task modal

### DIFF
--- a/wondrous-app/components/Common/Task/modal.tsx
+++ b/wondrous-app/components/Common/Task/modal.tsx
@@ -773,6 +773,7 @@ export const TaskViewModal = (props: ITaskListModalProps) => {
 
   const [getTaskById] = useLazyQuery(GET_TASK_BY_ID, {
     fetchPolicy: 'network-only',
+    nextFetchPolicy: 'cache-and-network',
     onCompleted: (data) => {
       const taskData = data?.getTaskById;
       if (taskData) {

--- a/wondrous-app/components/Common/Task/modal.tsx
+++ b/wondrous-app/components/Common/Task/modal.tsx
@@ -773,7 +773,6 @@ export const TaskViewModal = (props: ITaskListModalProps) => {
 
   const [getTaskById] = useLazyQuery(GET_TASK_BY_ID, {
     fetchPolicy: 'network-only',
-    nextFetchPolicy: 'cache-and-network',
     onCompleted: (data) => {
       const taskData = data?.getTaskById;
       if (taskData) {
@@ -857,28 +856,31 @@ export const TaskViewModal = (props: ITaskListModalProps) => {
   );
 
   useEffect(() => {
-    if (!initialStatus) {
-      setInitialStatus(fetchedTask?.status);
-    }
-
-    if (
-      updateTaskStatusMutationData?.updateTaskStatus.status === TASK_STATUS_ARCHIVED ||
-      updateBountyStatusData?.updateBountyStatus.status === TASK_STATUS_ARCHIVED
-    ) {
-      setSnackbarAlertOpen(true);
-      setSnackbarAlertMessage(
-        <>
-          Task archived successfully!{' '}
-          <ArchivedTaskUndo
-            onClick={() => {
-              handleNewStatus(initialStatus);
-              setSnackbarAlertOpen(false);
-            }}
-          >
-            Undo
-          </ArchivedTaskUndo>
-        </>
-      );
+    if (open) {
+      if (initialStatus !== TASK_STATUS_ARCHIVED) {
+        setInitialStatus(fetchedTask?.status);
+      }
+      const archived = [
+        updateTaskStatusMutationData?.updateTaskStatus.status,
+        updateBountyStatusData?.updateBountyStatus.status,
+      ].some((i) => i?.includes(TASK_STATUS_ARCHIVED));
+      if (archived) {
+        handleClose();
+        setSnackbarAlertOpen(true);
+        setSnackbarAlertMessage(
+          <>
+            Task archived successfully!{' '}
+            <ArchivedTaskUndo
+              onClick={() => {
+                handleNewStatus(initialStatus);
+                setSnackbarAlertOpen(false);
+              }}
+            >
+              Undo
+            </ArchivedTaskUndo>
+          </>
+        );
+      }
     }
   }, [
     initialStatus,
@@ -889,7 +891,10 @@ export const TaskViewModal = (props: ITaskListModalProps) => {
     setSnackbarAlertMessage,
     handleNewStatus,
     updateBountyStatusData,
+    handleClose,
+    open,
   ]);
+
   useEffect(() => {
     if (isMilestone) {
       setActiveTab(tabs.tasks);


### PR DESCRIPTION
Task: https://app.wonderverse.xyz/dashboard?task=46094456565268510&view=grid

Changes:
1. Feat: close the task view modal after archiving a task
2. Fix: Undoing a task reverts to the initial status instead of the recent status. To reproduce:
    1. View a task then close
    2. Move the card to a new status (e.g. to do -> in progress)
    3. View the task then archive
    4. Undo

**Before the update**

https://user-images.githubusercontent.com/8164667/162601131-0bfaa477-addf-4a9e-a85a-66e411af4960.mp4

**After the update**

https://user-images.githubusercontent.com/8164667/162601138-956dd6b4-283f-4579-95ee-5e69f94274cd.mp4