### PR TITLE
fix: "member" header is incorrect

### DIFF
--- a/wondrous-app/components/Settings/Members/index.tsx
+++ b/wondrous-app/components/Settings/Members/index.tsx
@@ -228,7 +228,7 @@ const Members = (props) => {
           <StyledTable>
             <StyledTableHead>
               <StyledTableRow>
-                <StyledTableHeaderCell width="50%">Currency</StyledTableHeaderCell>
+                <StyledTableHeaderCell width="50%">Members</StyledTableHeaderCell>
                 <StyledTableHeaderCell width="30%">Role</StyledTableHeaderCell>
                 <StyledTableHeaderCell width="15%">Pods</StyledTableHeaderCell>
                 <StyledTableHeaderCell width="5%">Edit</StyledTableHeaderCell>


### PR DESCRIPTION
task: https://app.wonderverse.xyz/organization/wonderverse/boards?task=56707947839881265&view=grid

**Before**

<img width="248" alt="image" src="https://user-images.githubusercontent.com/8164667/169446820-9485b039-2b15-4d61-916d-4cb16951b243.png">


**After**

<img width="251" alt="image" src="https://user-images.githubusercontent.com/8164667/169446764-ac168508-2ad8-4dbb-94f9-91a0bfbf76ea.png">
