### PR TITLE
fix: Color shuffling not working for tags

### DIFF
--- a/wondrous-app/components/Tags/index.tsx
+++ b/wondrous-app/components/Tags/index.tsx
@@ -43,7 +43,7 @@ function Tags({ options, onChange, onCreate, limit, ids = [] }: Props) {
   const [randomColor, setRandomColor] = useState(randomColors[0]);
 
   const generateRandomColor = () => {
-    return options.length <  colors.length
+    return options.length < colors.length
       ? // pick random color that doesn't exist in the option
         colors.find((color) => !options.some((option) => option.color === color))
       : _.shuffle(colors)[0];
@@ -69,28 +69,33 @@ function Tags({ options, onChange, onCreate, limit, ids = [] }: Props) {
 
         const tagOrNewTagName = tags[tags.length - 1];
 
-        if (tagOrNewTagName) {
-          if (typeof tagOrNewTagName === 'string') {
-            const option = options.find((option) => option.name === tagOrNewTagName);
+        if (!tagOrNewTagName) {
+          onChange([]);
 
-            if (option) {
-              const selected = ids.find((id) => option.id === id);
-
-              if (!selected) {
-                tags.push(option);
-              }
-            } else {
-              onCreate({
-                name: tagOrNewTagName,
-                color: randomColor,
-              } as Option);
-            }
-          } else if (!tagOrNewTagName.id) {
-            onCreate(tagOrNewTagName);
-          }
+          return;
         }
 
-        onChange(tags.map((tag) => tag.id));
+        if (typeof tagOrNewTagName === 'string') {
+          const option = options.find((option) => option.name === tagOrNewTagName);
+
+          if (option) {
+            const selected = ids.find((id) => option.id === id);
+
+            if (!selected) {
+              tags[tags.length - 1] = option;
+              onChange(tags.map((tag) => tag.id));
+            }
+          } else {
+            onCreate({
+              name: tagOrNewTagName,
+              color: randomColor,
+            } as Option);
+          }
+        } else if (tagOrNewTagName.id) {
+          onChange(tags.map((tag) => tag.id));
+        } else {
+          onCreate(tagOrNewTagName);
+        }
       }}
       getOptionLabel={(option) => option.name}
       filterOptions={(options, params) => {
@@ -133,7 +138,7 @@ function Tags({ options, onChange, onCreate, limit, ids = [] }: Props) {
               icon={<span>&times;</span>}
               onClick={props.onDelete}
               label={option.name}
-              bgColor={option.color}
+              background={option.color}
               variant="outlined"
             />
           );

--- a/wondrous-app/components/Tags/index.tsx
+++ b/wondrous-app/components/Tags/index.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { useEffect, useState } from 'react';
 import { TextField } from '@material-ui/core';
 import { createFilterOptions } from '@material-ui/lab';
 import _ from 'lodash';
@@ -35,18 +35,23 @@ const filter = createFilterOptions({
   stringify: (option: Option) => option.name || '',
 });
 
-const colors = _.shuffle(Object.values(ColorTypes));
+const colors = Object.values(ColorTypes);
+const randomColors = _.shuffle(colors);
 
 function Tags({ options, onChange, onCreate, limit, ids = [] }: Props) {
-  const getRandomColor = (): string => {
-    return options.length <= colors.length
+  const [openTags, setOpenTags] = useState(false);
+  const [randomColor, setRandomColor] = useState(randomColors[0]);
+
+  const generateRandomColor = () => {
+    return options.length <  colors.length
       ? // pick random color that doesn't exist in the option
         colors.find((color) => !options.some((option) => option.color === color))
-      : colors[0];
+      : _.shuffle(colors)[0];
   };
 
-  const [openTags, setOpenTags] = useState(false);
-  const [randomColor, setRandomColor] = useState(getRandomColor());
+  useEffect(() => {
+    setRandomColor(generateRandomColor());
+  }, [options]);
 
   return (
     <StyledAutocomplete
@@ -66,15 +71,22 @@ function Tags({ options, onChange, onCreate, limit, ids = [] }: Props) {
 
         if (tagOrNewTagName) {
           if (typeof tagOrNewTagName === 'string') {
-            onCreate({
-              name: tagOrNewTagName,
-              color: randomColor,
-            } as Option);
-            return setRandomColor(randomColor);
+            const option = options.find((option) => option.name === tagOrNewTagName);
+
+            if (option) {
+              const selected = ids.find((id) => option.id === id);
+
+              if (!selected) {
+                tags.push(option);
+              }
+            } else {
+              onCreate({
+                name: tagOrNewTagName,
+                color: randomColor,
+              } as Option);
+            }
           } else if (!tagOrNewTagName.id) {
             onCreate(tagOrNewTagName);
-
-            return setRandomColor(getRandomColor());
           }
         }
 

--- a/wondrous-app/components/Tags/styles.tsx
+++ b/wondrous-app/components/Tags/styles.tsx
@@ -62,19 +62,19 @@ export const OptionItem = styled.li`
 
 export const StyledChipTag = styled(Chip)`
   &&& {
-    color: ${props => getContrastYIQ(props.bgColor)};
-    background: ${props => props.bgColor};
+    color: ${props => getContrastYIQ(props.background)};
+    background: ${props => props.background};
     border: 0;
     border-radius: 6px;
     height: 25px;
     margin-right: 6px;
     
     > span {
-      color: ${props => getContrastYIQ(props.bgColor)};
+      color: ${props => getContrastYIQ(props.background)};
     }
     
     &:hover {
-      background: ${props => props.bgColor};
+      background: ${props => props.background};
       opacity: 0.8;
     }
   }


### PR DESCRIPTION
**Fixes for tags:** 
- pick a random color after creating the tag
- don't create a new tag if the tag with the same name already exists
- select tag with the same name by enter 