### PR TITLE
fix: new milestone is not selected

### DIFF
--- a/wondrous-app/components/CreateEntity/CreateEntityModal/MilestoneSearch/index.tsx
+++ b/wondrous-app/components/CreateEntity/CreateEntityModal/MilestoneSearch/index.tsx
@@ -27,7 +27,7 @@ import {
 } from './styles';
 
 const MilestoneSearch = (props) => {
-  const { options, onChange, value, handleClose } = props;
+  const { options, onChange, value, handleClose, formValues = null } = props;
   const [createMilestone, setCreateMilestone] = useState(false);
 
   const [anchorEl, setAnchorEl] = useState(null);
@@ -55,6 +55,7 @@ const MilestoneSearch = (props) => {
           handleClickAway();
           onChange(data?.createMilestone?.id);
         }}
+        formValues={formValues}
       />
     );
   }

--- a/wondrous-app/components/CreateEntity/CreateEntityModal/PodSearch/index.tsx
+++ b/wondrous-app/components/CreateEntity/CreateEntityModal/PodSearch/index.tsx
@@ -20,7 +20,7 @@ import {
 } from './styles';
 
 const PodSearch = (props) => {
-  const { options, onChange, value } = props;
+  const { options, onChange, value, disabled } = props;
   const [anchorEl, setAnchorEl] = useState(null);
   const handleClick = (event) => setAnchorEl(anchorEl ? null : event.currentTarget);
   const handleClickAway = () => setAnchorEl(null);
@@ -29,7 +29,7 @@ const PodSearch = (props) => {
   return (
     <PodSearchClickAway onClickAway={handleClickAway}>
       <PodSearchWrapper>
-        <PodSearchButton open={open} disabled={!options} onClick={handleClick}>
+        <PodSearchButton open={open} disabled={!options || disabled} onClick={handleClick}>
           <PodSearchImageLabelWrapper>
             <PodSearchDefaultImage color={selectedValue?.color ?? `#474747`} />
             <PodSearchLabel>{selectedValue?.label ?? `Select a Pod`}</PodSearchLabel>

--- a/wondrous-app/components/CreateEntity/CreateEntityModal/index.tsx
+++ b/wondrous-app/components/CreateEntity/CreateEntityModal/index.tsx
@@ -813,7 +813,7 @@ interface ICreateEntityModal {
   parentTaskId?: string;
   resetEntityType?: Function;
   setEntityType?: Function;
-  formValues: FormikValues;
+  formValues?: FormikValues;
 }
 
 export const CreateEntityModal = (props: ICreateEntityModal) => {

--- a/wondrous-app/components/CreateEntity/index.tsx
+++ b/wondrous-app/components/CreateEntity/index.tsx
@@ -1,3 +1,4 @@
+import { FormikValues } from 'formik';
 import { useState } from 'react';
 import { ENTITIES_TYPES } from 'utils/constants';
 import ChooseEntityToCreateModal from './chooseEntityToCreateModal';
@@ -13,6 +14,7 @@ interface ICreateEntity {
   open: Boolean;
   handleCloseModal: Function;
   isTaskProposal?: boolean;
+  formValues: FormikValues;
 }
 
 export const CreateEntity = (props: ICreateEntity) => {

--- a/wondrous-app/components/CreateEntity/index.tsx
+++ b/wondrous-app/components/CreateEntity/index.tsx
@@ -14,7 +14,7 @@ interface ICreateEntity {
   open: Boolean;
   handleCloseModal: Function;
   isTaskProposal?: boolean;
-  formValues: FormikValues;
+  formValues?: FormikValues;
 }
 
 export const CreateEntity = (props: ICreateEntity) => {


### PR DESCRIPTION
1. When creating/editing a task, if the user added a new milestone, the milestone will be picked automatically.
2. When a user adds a new milestone while creating/editing a task, the new milestone's org/pod is limited to the org/pod specified from the new task's form.

demo: https://www.loom.com/share/9582f3d49ce649498c963dce860f330f