### PR TITLE
added org to explore bounty board while keeping pod info on org board

### DIFF
--- a/wondrous-app/components/Common/BountyBoard/index.tsx
+++ b/wondrous-app/components/Common/BountyBoard/index.tsx
@@ -31,6 +31,7 @@ import { useRouter } from 'next/router';
 import { TASK_ICONS } from 'components/Common/Task/index';
 import { CompletedIcon } from 'components/Icons/statusIcons';
 import { RichTextViewer } from 'components/RichText';
+import { DAOIcon } from 'components/Icons/dao';
 
 export const SubmissionsCount = ({ total, approved }) => {
   const config = [
@@ -57,7 +58,7 @@ export const SubmissionsCount = ({ total, approved }) => {
     </BountyCardSubmissionsCountWrapper>
   );
 };
-export default function Board({ tasks, handleCardClick = (bounty) => {} }) {
+export default function Board({ tasks, handleCardClick = (bounty) => {}, displayOrg = false }) {
   const router = useRouter();
   const goToPod = (podId) => {
     router.push(`/pod/${podId}/boards`, undefined, {
@@ -65,12 +66,12 @@ export default function Board({ tasks, handleCardClick = (bounty) => {} }) {
     });
   };
 
+  const goToOrg = (orgId) => router.push(`/org/${orgId}/boards`, undefined, { shallow: true });
+
   return (
     <>
       {tasks.map((bounty) => {
         const reward = bounty?.rewards?.[0];
-        const rewardSymbol = reward?.symbol?.toLowerCase() || 'eth';
-        const rewardAmount = reward?.rewardAmount || null;
         let BountyStatusIcon = TASK_ICONS[bounty?.status];
         return (
           <BountyCardWrapper onClick={() => handleCardClick(bounty)} key={bounty.id}>
@@ -105,7 +106,7 @@ export default function Board({ tasks, handleCardClick = (bounty) => {} }) {
               <SubmissionsCount total={bounty.totalSubmissionsCount} approved={bounty.approvedSubmissionsCount} />
             </BoardsCardBody>
             <BoardsCardFooter>
-              {bounty?.podName && (
+              {bounty?.podName && !displayOrg && (
                 <PodWrapper
                   style={{ marginTop: '0' }}
                   onClick={(e) => {
@@ -123,6 +124,32 @@ export default function Board({ tasks, handleCardClick = (bounty) => {} }) {
                     }}
                   />
                   <PodName>{bounty?.podName}</PodName>
+                </PodWrapper>
+              )}
+              {displayOrg && (
+                <PodWrapper
+                  style={{ marginTop: '0', alignItems: 'center' }}
+                  onClick={(e) => {
+                    e.preventDefault();
+                    e.stopPropagation();
+                    goToOrg(bounty?.orgId);
+                  }}
+                >
+                  {bounty?.orgProfilePicture ? (
+                    <SafeImage
+                      src={bounty.orgProfilePicture}
+                      style={{
+                        width: '26px',
+                        height: '26px',
+                        borderRadius: '4px',
+                        marginRight: '8px',
+                      }}
+                    />
+                  ) : (
+                    <DAOIcon />
+                  )}
+
+                  <PodName>{bounty?.orgName}</PodName>
                 </PodWrapper>
               )}
               <div

--- a/wondrous-app/components/Explore/sections.tsx
+++ b/wondrous-app/components/Explore/sections.tsx
@@ -129,7 +129,7 @@ export const BountySection = ({ isMobile, bounties = [], fetchMore = () => {}, h
           taskId={location?.params?.task?.toString()}
         />
 
-        <BountyBoard tasks={bounties} handleCardClick={handleCardClick} />
+        <BountyBoard tasks={bounties} displayOrg handleCardClick={handleCardClick} />
       </StyledGridContainer>
       {hasMore && !!bounties?.length && (
         <ShowMoreButtonWrapper>


### PR DESCRIPTION
<img width="702" alt="Screenshot 2022-07-14 at 02 07 51" src="https://user-images.githubusercontent.com/22411330/178852552-8e85d91f-3dbc-4be2-9730-c16df3ea21e6.png">


bounties display orgs on explore page

this change is part of the bug with submission count on explore pg, be dependency:  https://github.com/wondrous-dev/wondrous-backend/pull/475