### PR TITLE
fix: bounty copy text

### DIFF
--- a/wondrous-app/components/Common/Share/index.tsx
+++ b/wondrous-app/components/Common/Share/index.tsx
@@ -16,7 +16,7 @@ export const Share = (props: IShareProps) => {
     e.preventDefault();
     e.stopPropagation();
     navigator.clipboard.writeText(url);
-    setSnackbarAlertMessage('Task link copied');
+    setSnackbarAlertMessage('Bounty link copied');
     setSnackbarAlertOpen(true);
   };
   return (


### PR DESCRIPTION
Copy change - "Task link copied" to "Bounty link copied"

Before - 

![Screenshot from 2022-07-19 18-41-45](https://user-images.githubusercontent.com/61096193/179758484-a91e9263-297d-497f-9f2a-7798c6fd8b3d.png)

After -

![Screenshot from 2022-07-19 18-41-26](https://user-images.githubusercontent.com/61096193/179758504-d741b036-6717-4c35-bbbe-a2068d5f075a.png)

