### PR TITLE
unify proposals

### DIFF
--- a/wondrous-app/components/Common/KanbanBoard/TaskColumn/index.tsx
+++ b/wondrous-app/components/Common/KanbanBoard/TaskColumn/index.tsx
@@ -14,7 +14,7 @@ import {
   BOARD_TYPE,
   STATUS_OPEN,
   STATUS_APPROVED,
-  STATUS_CHANGE_REQUESTED,
+  STATUS_CLOSED,
 } from 'utils/constants';
 import { LIMIT } from 'services/board';
 import { ToDo, InProgress, Done, InReview, Proposal, Approved, Rejected } from '../../../Icons';
@@ -55,7 +55,7 @@ const TITLES = {
   //PROPOSALS
   [STATUS_OPEN]: 'Open',
   [STATUS_APPROVED]: 'Approved',
-  [STATUS_CHANGE_REQUESTED]: 'Rejected',
+  [STATUS_CLOSED]: 'Rejected',
 };
 
 const HEADER_ICONS = {
@@ -65,7 +65,7 @@ const HEADER_ICONS = {
   [TASK_STATUS_DONE]: Done,
   [STATUS_OPEN]: Proposal,
   [STATUS_APPROVED]: Approved,
-  [STATUS_CHANGE_REQUESTED]: Rejected,
+  [STATUS_CLOSED]: Rejected,
 };
 
 const TaskColumn = (props: ITaskColumn) => {
@@ -117,8 +117,8 @@ const TaskColumn = (props: ITaskColumn) => {
       number = taskCount?.proposalApproved || 0;
       taskColumnWidth = '33.3%';
       break;
-    case STATUS_CHANGE_REQUESTED:
-      number = taskCount?.proposalChangeRequested || 0;
+    case STATUS_CLOSED:
+      number = taskCount?.proposalClosed || 0;
       taskColumnWidth = '33.3%';
       break;
     default:

--- a/wondrous-app/components/Common/KanbanBoard/kanbanBoard.tsx
+++ b/wondrous-app/components/Common/KanbanBoard/kanbanBoard.tsx
@@ -10,7 +10,7 @@ import { ENTITIES_TYPES } from 'utils/constants';
 // Task update (column changes)
 import apollo from 'services/apollo';
 import { UPDATE_TASK_STATUS, UPDATE_TASK_ORDER } from 'graphql/mutations/task';
-import { APPROVE_TASK_PROPOSAL, REQUEST_CHANGE_TASK_PROPOSAL } from 'graphql/mutations/taskProposal';
+import { APPROVE_TASK_PROPOSAL, CLOSE_TASK_PROPOSAL } from 'graphql/mutations/taskProposal';
 import { disableContainerOverflow, enableContainerOverflow, parseUserPermissionContext } from 'utils/helpers';
 import {
   BOARD_TYPE,
@@ -18,7 +18,7 @@ import {
   PAYMENT_STATUS,
   TASK_TYPE,
   STATUS_APPROVED,
-  STATUS_CHANGE_REQUESTED,
+  STATUS_CLOSED,
   STATUS_OPEN,
   TASK_STATUS_DONE,
   TASK_STATUS_IN_REVIEW,
@@ -62,7 +62,7 @@ const KanbanBoard = (props) => {
   const [updateTaskOrder] = useMutation(UPDATE_TASK_ORDER);
   const [dndErrorModal, setDndErrorModal] = useState(false);
   const [approveTaskProposal] = useMutation(APPROVE_TASK_PROPOSAL);
-  const [requestChangeTaskProposal] = useMutation(REQUEST_CHANGE_TASK_PROPOSAL);
+  const [closeTaskProposal] = useMutation(CLOSE_TASK_PROPOSAL);
   const [taskToConfirm, setTaskToConfirm] = useState<any>(null);
   // Permissions for Draggable context
   const orgBoard = useOrgBoard();
@@ -229,8 +229,8 @@ const KanbanBoard = (props) => {
           });
           return;
         }
-        if (destinationStatus === STATUS_CHANGE_REQUESTED) {
-          requestChangeTaskProposal({
+        if (destinationStatus === STATUS_CLOSED) {
+          closeTaskProposal({
             variables: {
               proposalId: id,
             },

--- a/wondrous-app/components/Common/Task/card.tsx
+++ b/wondrous-app/components/Common/Task/card.tsx
@@ -497,7 +497,7 @@ export const TaskCard = ({
 
 const STATUS_ICONS = {
   [Constants.STATUS_APPROVED]: Approved,
-  [Constants.STATUS_CHANGE_REQUESTED]: Rejected,
+  [Constants.STATUS_CLOSED]: Rejected,
 };
 
 export function ProposalCard({ openModal, title, description, task, goToPod, proposalRequestChange, viewUrl }) {
@@ -527,7 +527,7 @@ export function ProposalCard({ openModal, title, description, task, goToPod, pro
         },
       ],
     },
-    [Constants.STATUS_CHANGE_REQUESTED]: {
+    [Constants.STATUS_CLOSED]: {
       labelsAndActions: [
         {
           title: 'Rejected',

--- a/wondrous-app/components/Common/Task/index.tsx
+++ b/wondrous-app/components/Common/Task/index.tsx
@@ -52,7 +52,7 @@ import { Arrow, Archived } from '../../Icons/sections';
 import { UPDATE_TASK_ASSIGNEE, ARCHIVE_TASK, UNARCHIVE_TASK } from 'graphql/mutations/task';
 import { GET_TASK_REVIEWERS } from 'graphql/queries';
 import { DeleteTaskModal } from '../DeleteTaskModal';
-import { REQUEST_CHANGE_TASK_PROPOSAL } from 'graphql/mutations/taskProposal';
+import { CLOSE_TASK_PROPOSAL } from 'graphql/mutations/taskProposal';
 import { getBoardType } from '../KanbanBoard/kanbanBoard';
 import { CreateEntity } from 'components/CreateEntity';
 
@@ -132,7 +132,7 @@ export const Task = (props) => {
   const isMilestone = type === Constants.ENTITIES_TYPES.MILESTONE;
   const isSubtask = task?.parentTaskId !== null;
   const isBounty = type === Constants.ENTITIES_TYPES.BOUNTY;
-  const [requestChangeTaskProposal] = useMutation(REQUEST_CHANGE_TASK_PROPOSAL);
+  const [closeTaskProposal] = useMutation(CLOSE_TASK_PROPOSAL);
 
   const [archiveTaskMutation, { data: archiveTaskData }] = useMutation(ARCHIVE_TASK, {
     refetchQueries: [
@@ -175,8 +175,8 @@ export const Task = (props) => {
 
   const reviewerData = useGetReviewers(editTask, task);
 
-  const proposalRequestChange = (id, status) => {
-    requestChangeTaskProposal({
+  const closeProposal = (id, status) => {
+    closeTaskProposal({
       variables: {
         proposalId: id,
       },
@@ -361,7 +361,7 @@ export const Task = (props) => {
         setArchiveTask={setArchiveTask}
         canDelete={canDelete}
         setDeleteTask={setDeleteTask}
-        proposalRequestChange={proposalRequestChange}
+        proposalRequestChange={closeProposal}
         boardType={getBoardType({
           orgBoard,
           podBoard,

--- a/wondrous-app/components/Common/TaskSummary/index.tsx
+++ b/wondrous-app/components/Common/TaskSummary/index.tsx
@@ -37,7 +37,7 @@ import { PERMISSIONS, TASK_STATUS_ARCHIVED, TASK_STATUS_IN_REVIEW, TASK_STATUS_R
 import { parseUserPermissionContext } from 'utils/helpers';
 import { CreateFormButtonsBlock, CreateFormFooterButtons, CreateFormPreviewButton } from '../../CreateEntity/styles';
 import { useMutation } from '@apollo/client';
-import { APPROVE_TASK_PROPOSAL, REQUEST_CHANGE_TASK_PROPOSAL } from 'graphql/mutations/taskProposal';
+import { APPROVE_TASK_PROPOSAL, CLOSE_TASK_PROPOSAL } from 'graphql/mutations/taskProposal';
 import { APPROVE_SUBMISSION, REQUEST_CHANGE_SUBMISSION } from 'graphql/mutations/taskSubmission';
 import { RejectIcon } from '../../Icons/taskModalIcons';
 import { CompletedIcon } from '../../Icons/statusIcons';
@@ -79,7 +79,7 @@ export const TaskSummary = ({ task, setTask, action, taskType }) => {
   let TaskIcon = TASK_ICONS[status];
   const [modalOpen, setModalOpen] = useState(false);
   const [approveTaskProposal] = useMutation(APPROVE_TASK_PROPOSAL);
-  const [requestChangeTaskProposal] = useMutation(REQUEST_CHANGE_TASK_PROPOSAL);
+  const [closeTaskProposal] = useMutation(CLOSE_TASK_PROPOSAL);
   const [approveTaskSubmission] = useMutation(APPROVE_SUBMISSION);
   const [requestChangeTaskSubmission] = useMutation(REQUEST_CHANGE_SUBMISSION);
   const location = useLocation();
@@ -141,7 +141,7 @@ export const TaskSummary = ({ task, setTask, action, taskType }) => {
         },
       });
     requestChange = () =>
-      requestChangeTaskProposal({
+      closeTaskProposal({
         variables: {
           proposalId: task?.id,
         },

--- a/wondrous-app/components/Common/TaskViewModal/taskMenuStatus.tsx
+++ b/wondrous-app/components/Common/TaskViewModal/taskMenuStatus.tsx
@@ -1,8 +1,8 @@
 import { useMutation } from '@apollo/client';
-import { APPROVE_TASK_PROPOSAL, REQUEST_CHANGE_TASK_PROPOSAL, UPDATE_TASK_STATUS } from 'graphql/mutations';
+import { APPROVE_TASK_PROPOSAL, CLOSE_TASK_PROPOSAL, UPDATE_TASK_STATUS } from 'graphql/mutations';
 import { useState } from 'react';
 import { ENTITIES_TYPES_FILTER_STATUSES } from 'services/board';
-import { STATUS_APPROVED, STATUS_CHANGE_REQUESTED, STATUS_OPEN, TASK_STATUS_ARCHIVED } from 'utils/constants';
+import { STATUS_APPROVED, STATUS_CLOSED, STATUS_OPEN, TASK_STATUS_ARCHIVED } from 'utils/constants';
 
 import {
   TaskModalStatusLabel,
@@ -14,7 +14,7 @@ import {
 
 const taskProposalStatus = (task) => {
   if (task?.approvedAt) return STATUS_APPROVED;
-  if (task?.changeRequestedAt) return STATUS_CHANGE_REQUESTED;
+  if (task?.closedAt) return STATUS_CLOSED;
   return STATUS_OPEN;
 };
 
@@ -42,7 +42,7 @@ const useTaskMenuStatusProposal = ({ task, entityType, taskId, canApproveProposa
   const [approveTaskProposal] = useMutation(APPROVE_TASK_PROPOSAL, {
     refetchQueries: refetchTaskProposalQueries,
   });
-  const [requestChangeTaskProposal] = useMutation(REQUEST_CHANGE_TASK_PROPOSAL, {
+  const [closeTaskProposal] = useMutation(CLOSE_TASK_PROPOSAL, {
     refetchQueries: refetchTaskProposalQueries,
   });
   const handleOnChange = (newStatus) => {
@@ -50,8 +50,8 @@ const useTaskMenuStatusProposal = ({ task, entityType, taskId, canApproveProposa
       approveTaskProposal({ variables: { proposalId: taskId } });
       return;
     }
-    if (newStatus === STATUS_CHANGE_REQUESTED) {
-      requestChangeTaskProposal({ variables: { proposalId: taskId } });
+    if (newStatus === STATUS_CLOSED) {
+      closeTaskProposal({ variables: { proposalId: taskId } });
       return;
     }
   };

--- a/wondrous-app/components/Common/TaskViewModal/taskViewModal.tsx
+++ b/wondrous-app/components/Common/TaskViewModal/taskViewModal.tsx
@@ -22,7 +22,7 @@ import {
 } from 'graphql/mutations/task';
 import {
   APPROVE_TASK_PROPOSAL,
-  REQUEST_CHANGE_TASK_PROPOSAL,
+  CLOSE_TASK_PROPOSAL,
   UPDATE_TASK_PROPOSAL_ASSIGNEE,
 } from 'graphql/mutations/taskProposal';
 import { GET_ORG_LABELS } from 'graphql/queries';
@@ -457,7 +457,7 @@ export const TaskViewModal = (props: ITaskListModalProps) => {
   const [removeTaskAssignee] = useMutation(REMOVE_TASK_ASSIGNEE);
   const [updateTaskProposalAssignee] = useMutation(UPDATE_TASK_PROPOSAL_ASSIGNEE);
   const [approveTaskProposal] = useMutation(APPROVE_TASK_PROPOSAL);
-  const [requestChangeTaskProposal] = useMutation(REQUEST_CHANGE_TASK_PROPOSAL);
+  const [closeTaskProposal] = useMutation(CLOSE_TASK_PROPOSAL);
   const [completeMilestone] = useMutation(COMPLETE_MILESTONE, {
     refetchQueries: () => [
       'getTaskById',
@@ -895,8 +895,8 @@ export const TaskViewModal = (props: ITaskListModalProps) => {
     });
   };
 
-  const requestProposalChanges = () => {
-    requestChangeTaskProposal({
+  const closeProposal = () => {
+    closeTaskProposal({
       variables: {
         proposalId: fetchedTask?.id,
       },
@@ -1439,7 +1439,7 @@ export const TaskViewModal = (props: ITaskListModalProps) => {
                         {canApproveProposal && !fetchedTask?.approvedAt && (
                           <CreateFormButtonsBlock>
                             {!fetchedTask?.changeRequestedAt && (
-                              <CreateFormCancelButton onClick={requestProposalChanges}>Reject</CreateFormCancelButton>
+                              <CreateFormCancelButton onClick={closeProposal}>Reject</CreateFormCancelButton>
                             )}
                             <CreateFormPreviewButton onClick={approveProposal}>Approve</CreateFormPreviewButton>
                           </CreateFormButtonsBlock>

--- a/wondrous-app/components/CreateEntity/CreateEntityModal/index.tsx
+++ b/wondrous-app/components/CreateEntity/CreateEntityModal/index.tsx
@@ -753,10 +753,12 @@ const useCreateTaskProposal = () => {
   const [createTaskProposal, { loading }] = useMutation(CREATE_TASK_PROPOSAL, {
     refetchQueries: () => [
       'GetOrgTaskBoardProposals',
-      'GetPodTaskBoardProposals',
+      'getPodTaskBoardProposals',
       'GetUserTaskBoardProposals',
       'getPerTypeTaskCountForOrgBoard',
       'getPerTypeTaskCountForPodBoard',
+      'getPerStatusTaskCountForOrgBoard',
+      'getPerStatusTaskCountForOrgBoard',
     ],
   });
 
@@ -794,7 +796,7 @@ const useUpdateTaskProposal = () => {
     refetchQueries: () => [
       'GetUserTaskBoardProposals',
       'GetOrgTaskBoardProposals',
-      'GetPodTaskBoardProposals',
+      'getPodTaskBoardProposals',
       'getPerTypeTaskCountForOrgBoard',
       'getPerTypeTaskCountForPodBoard',
     ],

--- a/wondrous-app/components/CreateEntity/editEntityModal.tsx
+++ b/wondrous-app/components/CreateEntity/editEntityModal.tsx
@@ -142,9 +142,9 @@ const EditLayoutBaseModal = (props) => {
   const [pod, setPod] = useState(existingTask?.podName && existingTask?.podId);
   const [dueDate, setDueDate] = useState(existingTask?.dueDate);
   const proposalRejected = existingTask?.rejectedAt;
-  const proposalChangeRequested = existingTask?.changeRequestedAt;
+  const proposalClosed = existingTask?.closedAt;
   const proposalApproved = existingTask?.approvedAt;
-  const proposalOpen = !proposalRejected && !proposalChangeRequested && !proposalApproved;
+  const proposalOpen = !proposalRejected && !proposalClosed && !proposalApproved;
   const [fileUploadLoading, setFileUploadLoading] = useState(false);
 
   const isTask = entityType === ENTITIES_TYPES.TASK;

--- a/wondrous-app/components/DropDownDecision/DropDownPopper/index.tsx
+++ b/wondrous-app/components/DropDownDecision/DropDownPopper/index.tsx
@@ -19,35 +19,29 @@ import { ApproveAndPayIcon, ApproveOnlyIcon, RejectIcon, SendIntoRevisionIcon } 
 import { StyledList, StyledListItem, StyledListItemIcon, StyledListItemText, StyledPopper } from './styles';
 import { ErrorModal } from 'components/Common/ErrorModal';
 
-const DECISIONS = [
+const SUBMISSION_DECISIONS = [
   [DECISION_SEND_INTO_REVISION, SendIntoRevisionIcon],
   [DECISION_REJECT, RejectIcon],
   [DECISION_APPROVE_ONLY, ApproveOnlyIcon],
   // [DECISION_APPROVE_AND_PAY, ApproveAndPayIcon], NOTE: Per Terry's instruction, payments should be hidden for now in Admin View
 ];
 
+const PROPOSAL_DECISIONS = [
+  [DECISION_REJECT, RejectIcon],
+  [DECISION_APPROVE_ONLY, ApproveOnlyIcon],
+];
 export const DropDownPopper = (props) => {
   const { task, status, onClose, openKudos, setKudosTask } = props;
   const [closeTaskProposal] = useMutation(CLOSE_TASK_PROPOSAL);
   const [approveTaskProposal] = useMutation(APPROVE_TASK_PROPOSAL);
-  const [rejectTaskProposal] = useMutation(CLOSE_TASK_PROPOSAL);
   const [approveTaskSubmission] = useMutation(APPROVE_SUBMISSION);
   const [requestChangeTaskSubmission] = useMutation(REQUEST_CHANGE_SUBMISSION);
   const [rejectTaskSubmission] = useMutation(REJECT_SUBMISSION);
   const [submissionApprovalError, setSubmissionApprovalError] = useState(null);
   const handleTaskProposalDecision = (id, decision) => {
     const refetchQueries = () => ['getProposalsUserCanReview', 'getWorkFlowBoardReviewableItemsCount'];
-    if (decision === DECISION_SEND_INTO_REVISION) {
-      closeTaskProposal({
-        variables: {
-          proposalId: id,
-        },
-        refetchQueries: refetchQueries(),
-      });
-    }
-
     if (decision === DECISION_REJECT) {
-      rejectTaskProposal({
+      closeTaskProposal({
         variables: {
           proposalId: id,
         },
@@ -119,6 +113,7 @@ export const DropDownPopper = (props) => {
     onClose();
   };
 
+  const DECISIONS = status === TASK_STATUS_PROPOSAL_REQUEST ? PROPOSAL_DECISIONS : SUBMISSION_DECISIONS;
   return (
     <>
       {submissionApprovalError && (

--- a/wondrous-app/components/DropDownDecision/DropDownPopper/index.tsx
+++ b/wondrous-app/components/DropDownDecision/DropDownPopper/index.tsx
@@ -3,10 +3,9 @@ import { useMutation } from '@apollo/client';
 import {
   APPROVE_SUBMISSION,
   APPROVE_TASK_PROPOSAL,
-  CLOSE_TASK_PROPOSAL,
   REJECT_SUBMISSION,
   REQUEST_CHANGE_SUBMISSION,
-  REQUEST_CHANGE_TASK_PROPOSAL,
+  CLOSE_TASK_PROPOSAL,
 } from 'graphql/mutations';
 import {
   DECISION_APPROVE_AND_PAY,
@@ -29,7 +28,7 @@ const DECISIONS = [
 
 export const DropDownPopper = (props) => {
   const { task, status, onClose, openKudos, setKudosTask } = props;
-  const [requestChangeTaskProposal] = useMutation(REQUEST_CHANGE_TASK_PROPOSAL);
+  const [closeTaskProposal] = useMutation(CLOSE_TASK_PROPOSAL);
   const [approveTaskProposal] = useMutation(APPROVE_TASK_PROPOSAL);
   const [rejectTaskProposal] = useMutation(CLOSE_TASK_PROPOSAL);
   const [approveTaskSubmission] = useMutation(APPROVE_SUBMISSION);
@@ -39,7 +38,7 @@ export const DropDownPopper = (props) => {
   const handleTaskProposalDecision = (id, decision) => {
     const refetchQueries = () => ['getProposalsUserCanReview', 'getWorkFlowBoardReviewableItemsCount'];
     if (decision === DECISION_SEND_INTO_REVISION) {
-      requestChangeTaskProposal({
+      closeTaskProposal({
         variables: {
           proposalId: id,
         },

--- a/wondrous-app/components/ListView/index.tsx
+++ b/wondrous-app/components/ListView/index.tsx
@@ -7,10 +7,10 @@ import {
   TASK_STATUS_DONE,
   ENTITIES_TYPES,
   STATUS_APPROVED,
-  STATUS_CHANGE_REQUESTED,
   PERMISSIONS,
   PAYMENT_STATUS,
   BOARD_TYPE,
+  STATUS_CLOSED,
 } from 'utils/constants';
 import { useState, useEffect } from 'react';
 import { useLocation } from 'utils/useLocation';
@@ -22,7 +22,7 @@ import { Droppable } from 'react-beautiful-dnd';
 import { useMe } from 'components/Auth/withAuth';
 import { parseUserPermissionContext } from 'utils/helpers';
 import { useMutation } from '@apollo/client';
-import { APPROVE_TASK_PROPOSAL, REQUEST_CHANGE_TASK_PROPOSAL } from 'graphql/mutations/taskProposal';
+import { APPROVE_TASK_PROPOSAL, CLOSE_TASK_PROPOSAL } from 'graphql/mutations/taskProposal';
 import { populateOrder } from 'components/Common/KanbanBoard/kanbanBoard';
 import { UPDATE_TASK_STATUS, UPDATE_TASK_ORDER } from 'graphql/mutations/task';
 import apollo from 'services/apollo';
@@ -51,7 +51,7 @@ export default function ListView({ columns, onLoadMore, hasMore, ...props }: Pro
   const location = useLocation();
   const isProposalEntity = entityType === ENTITIES_TYPES.PROPOSAL;
   const [approveTaskProposal] = useMutation(APPROVE_TASK_PROPOSAL);
-  const [requestChangeTaskProposal] = useMutation(REQUEST_CHANGE_TASK_PROPOSAL);
+  const [closeTaskProposal] = useMutation(CLOSE_TASK_PROPOSAL);
   const [updateTaskOrder] = useMutation(UPDATE_TASK_ORDER);
   const [dndErrorModal, setDndErrorModal] = useState(false);
 
@@ -125,8 +125,8 @@ export default function ListView({ columns, onLoadMore, hasMore, ...props }: Pro
           });
           return;
         }
-        if (destinationStatus === STATUS_CHANGE_REQUESTED) {
-          requestChangeTaskProposal({
+        if (destinationStatus === STATUS_CLOSED) {
+          closeTaskProposal({
             variables: {
               proposalId: id,
             },

--- a/wondrous-app/graphql/fragments/task.ts
+++ b/wondrous-app/graphql/fragments/task.ts
@@ -177,7 +177,7 @@ export const TaskProposalCardFragment = gql`
     title
     description
     approvedAt
-    changeRequestedAt
+    closedAt
     lastReviewedBy
     rejectedAt
     rewards {
@@ -298,7 +298,7 @@ export const TaskProposalFragment = gql`
     }
     userMentions
     approvedAt
-    changeRequestedAt
+    closedAt
     rejectedAt
     lastReviewedBy
     associatedTaskId

--- a/wondrous-app/graphql/queries/taskBoard.ts
+++ b/wondrous-app/graphql/queries/taskBoard.ts
@@ -323,7 +323,7 @@ export const GET_PER_STATUS_TASK_COUNT_FOR_ORG_BOARD = gql`
       inReview
       proposalOpen
       proposalApproved
-      proposalChangeRequested
+      proposalClosed
     }
   }
 `;
@@ -382,7 +382,7 @@ export const GET_PER_STATUS_TASK_COUNT_FOR_POD_BOARD = gql`
       inReview
       proposalOpen
       proposalApproved
-      proposalChangeRequested
+      proposalClosed
     }
   }
 `;

--- a/wondrous-app/pages/organization/[username]/boards.tsx
+++ b/wondrous-app/pages/organization/[username]/boards.tsx
@@ -36,7 +36,7 @@ import {
   TASK_STATUS_REQUESTED,
   ENTITIES_TYPES,
   STATUS_APPROVED,
-  STATUS_CHANGE_REQUESTED,
+  STATUS_CLOSED,
   PROPOSAL_STATUS_LIST,
 } from 'utils/constants';
 import { OrgBoardContext } from 'utils/contexts';
@@ -274,7 +274,7 @@ const useGetOrgTaskBoardProposals = ({
       const proposalBoardStatuses =
         filters?.statuses?.length > 0
           ? filters?.statuses?.filter((status) => PROPOSAL_STATUS_LIST.includes(status))
-          : [STATUS_OPEN, STATUS_CHANGE_REQUESTED, STATUS_APPROVED];
+          : [STATUS_OPEN, STATUS_CLOSED, STATUS_APPROVED];
       getOrgTaskProposals({
         variables: {
           podIds: filters?.podIds,

--- a/wondrous-app/pages/pod/[podId]/boards.tsx
+++ b/wondrous-app/pages/pod/[podId]/boards.tsx
@@ -34,9 +34,9 @@ import {
   TASK_STATUSES,
   ENTITIES_TYPES,
   STATUSES_ON_ENTITY_TYPES,
-  STATUS_CHANGE_REQUESTED,
   STATUS_APPROVED,
   PROPOSAL_STATUS_LIST,
+  STATUS_CLOSED,
 } from 'utils/constants';
 import { PodBoardContext } from 'utils/contexts';
 import _ from 'lodash';
@@ -208,7 +208,7 @@ const useGetPodTaskProposals = ({
     const proposalBoardStatuses =
       statuses?.length > 0
         ? statuses?.filter((status) => PROPOSAL_STATUS_LIST.includes(status))
-        : [STATUS_OPEN, STATUS_CHANGE_REQUESTED, STATUS_APPROVED];
+        : [STATUS_OPEN, STATUS_CLOSED, STATUS_APPROVED];
     if (entityType === ENTITIES_TYPES.PROPOSAL && !search && podId)
       getPodTaskProposals({
         variables: {

--- a/wondrous-app/services/board.tsx
+++ b/wondrous-app/services/board.tsx
@@ -11,11 +11,11 @@ import {
   COLUMNS_CONFIGURATION,
   STATUS_OPEN,
   STATUS_APPROVED,
-  STATUS_CHANGE_REQUESTED,
   ENTITIES_TYPES,
   TASK_DATE_OVERDUE,
   TASK_DATE_DUE_THIS_WEEK,
   TASK_DATE_DUE_NEXT_WEEK,
+  STATUS_CLOSED,
 } from 'utils/constants';
 import { Archived, InReview, Requested } from 'components/Icons/sections';
 import { StatusDefaultIcon } from 'components/Icons/statusIcons';
@@ -132,7 +132,7 @@ const PROPOSAL_APPROVED = {
 const PROPOSAL_REJECTED = {
   title: 'Rejected',
   tasks: [],
-  status: STATUS_CHANGE_REQUESTED,
+  status: STATUS_CLOSED,
 };
 
 const SHARED_FILTER_STATUSES_DATA = {
@@ -461,7 +461,7 @@ export const ENTITIES_TYPES_FILTER_STATUSES = ({ orgId, enablePodFilter = false 
               pillIcon: Approved,
             },
             {
-              id: STATUS_CHANGE_REQUESTED,
+              id: STATUS_CLOSED,
               name: 'Rejected proposals',
               label: 'Rejected',
               icon: <Rejected />,
@@ -625,15 +625,13 @@ export const populateProposalColumns = (proposals, columns) => {
     [STATUS_OPEN]: [],
     [STATUS_APPROVED]: [],
     // changes requested
-    [STATUS_CHANGE_REQUESTED]: [],
+    [STATUS_CLOSED]: [],
   };
   //temporary flag until we add a flag on BE?
   proposals?.forEach((proposal) => {
     if (proposal.approvedAt) proposalsMap[STATUS_APPROVED].push({ ...proposal, isProposal: true });
-    if (!proposal.approvedAt && !proposal.changeRequestedAt)
-      proposalsMap[STATUS_OPEN].push({ ...proposal, isProposal: true });
-    if (proposal.changeRequestedAt && !proposal.approvedAt)
-      proposalsMap[STATUS_CHANGE_REQUESTED].push({ ...proposal, isProposal: true });
+    if (!proposal.approvedAt && !proposal.closedAt) proposalsMap[STATUS_OPEN].push({ ...proposal, isProposal: true });
+    if (proposal.closedAt && !proposal.approvedAt) proposalsMap[STATUS_CLOSED].push({ ...proposal, isProposal: true });
   });
   return columns.map((column) => {
     return {

--- a/wondrous-app/utils/board.tsx
+++ b/wondrous-app/utils/board.tsx
@@ -6,8 +6,8 @@ import {
   TASK_STATUS_REQUESTED,
   STATUS_APPROVED,
   STATUS_OPEN,
-  STATUS_CHANGE_REQUESTED,
   ENTITIES_TYPES,
+  STATUS_CLOSED,
 } from './constants';
 
 export const addProposalItem = (newItem, columns) => {
@@ -43,7 +43,7 @@ export const getProposalStatus = (proposal) => {
 
   if (proposal?.approvedAt) proposalStatus = STATUS_APPROVED;
   if (!proposal?.approvedAt && !proposal?.changeRequested) proposalStatus = STATUS_OPEN;
-  if (proposal?.changeRequestedAt) proposalStatus = STATUS_CHANGE_REQUESTED;
+  if (proposal?.statusClosed) proposalStatus = STATUS_CLOSED;
   return proposalStatus;
 };
 

--- a/wondrous-app/utils/constants.ts
+++ b/wondrous-app/utils/constants.ts
@@ -30,9 +30,9 @@ export const COLUMN_TITLE_ARCHIVED = 'Archived';
 
 export const STATUS_OPEN = 'open';
 export const STATUS_WAITING_FOR_REVIEW = 'waiting_for_review';
-export const STATUS_CHANGE_REQUESTED = 'change_requested';
 export const STATUS_APPROVED = 'approved';
 export const STATUS_REJECTED = 'rejected';
+export const STATUS_CLOSED = 'closed';
 // Task types
 export const TASK_TYPE = 'task';
 export const BOUNTY_TYPE = 'bounty';
@@ -264,7 +264,7 @@ export const STATUSES_ON_ENTITY_TYPES = {
   DEFAULT: DEFAULT_STATUSES,
 };
 
-export const PROPOSAL_STATUS_LIST = [STATUS_OPEN, STATUS_CHANGE_REQUESTED, STATUS_APPROVED, TASK_STATUS_ARCHIVED];
+export const PROPOSAL_STATUS_LIST = [STATUS_OPEN, STATUS_CLOSED, STATUS_APPROVED, TASK_STATUS_ARCHIVED];
 
 export const IMAGE_FILE_EXTENSIONS_TYPE_MAPPING = {
   gif: 'image/gif',


### PR DESCRIPTION
Unify proposals, replaced all the STATUS_CHANGE_REQUESTED with closed and replaced all the methods that were calling request change proposals with close proposal 
Schema changes. Task Proposal status Closed depends on closedAt, removed changeRequestedAt from proposal schema since it's no use anymore