### PR TITLE
fix: share message for different entities are the same

### DIFF
--- a/wondrous-app/components/Common/Share/index.tsx
+++ b/wondrous-app/components/Common/Share/index.tsx
@@ -2,18 +2,20 @@ import { TaskShareIcon } from 'components/Icons/taskShare';
 import Tooltip from 'components/Tooltip';
 import { useContext } from 'react';
 import { SnackbarAlertContext } from '../SnackbarAlert';
+import { TASK_TYPE } from 'utils/constants';
+import { capitalize } from 'utils/common';
 import { StyledShare } from './styles';
 
 interface IShareProps {
   url: string;
   className?: string;
-  isBounty?: boolean;
+  entityType?: string;
 }
 
 export const Share = (props: IShareProps) => {
-  const { url, className, isBounty = false } = props;
+  const { url, className, entityType = TASK_TYPE } = props;
   const { setSnackbarAlertOpen, setSnackbarAlertMessage } = useContext(SnackbarAlertContext);
-  const snackbarAlertMessage = isBounty ? 'Bounty link copied' : 'Task link copied';
+  const snackbarAlertMessage = capitalize(entityType) + ' link copied';
   const handleOnClick = (e) => {
     e.preventDefault();
     e.stopPropagation();

--- a/wondrous-app/components/Common/Share/index.tsx
+++ b/wondrous-app/components/Common/Share/index.tsx
@@ -7,16 +7,18 @@ import { StyledShare } from './styles';
 interface IShareProps {
   url: string;
   className?: string;
+  isBounty?: boolean;
 }
 
 export const Share = (props: IShareProps) => {
-  const { url, className } = props;
+  const { url, className, isBounty = false } = props;
   const { setSnackbarAlertOpen, setSnackbarAlertMessage } = useContext(SnackbarAlertContext);
+  const snackbarAlertMessage = isBounty ? 'Bounty link copied' : 'Task link copied';
   const handleOnClick = (e) => {
     e.preventDefault();
     e.stopPropagation();
     navigator.clipboard.writeText(url);
-    setSnackbarAlertMessage('Bounty link copied');
+    setSnackbarAlertMessage(snackbarAlertMessage);
     setSnackbarAlertOpen(true);
   };
   return (

--- a/wondrous-app/components/Common/TaskViewModal/taskViewModal.tsx
+++ b/wondrous-app/components/Common/TaskViewModal/taskViewModal.tsx
@@ -587,6 +587,7 @@ export const TaskViewModal = (props: ITaskListModalProps) => {
               <TaskModalHeaderWrapperRight>
                 {back && <TaskModalHeaderBackToList onClick={handleClose}>Back to list</TaskModalHeaderBackToList>}
                 <TaskModalHeaderShare
+                  isBounty={isBounty}
                   url={`${LINK}/organization/${fetchedTask?.orgUsername}/boards?task=${
                     isSubtask ? fetchedTask?.parentTaskId : taskId
                   }`}

--- a/wondrous-app/components/Common/TaskViewModal/taskViewModal.tsx
+++ b/wondrous-app/components/Common/TaskViewModal/taskViewModal.tsx
@@ -587,7 +587,7 @@ export const TaskViewModal = (props: ITaskListModalProps) => {
               <TaskModalHeaderWrapperRight>
                 {back && <TaskModalHeaderBackToList onClick={handleClose}>Back to list</TaskModalHeaderBackToList>}
                 <TaskModalHeaderShare
-                  isBounty={isBounty}
+                  entityType={entityType}
                   url={`${LINK}/organization/${fetchedTask?.orgUsername}/boards?task=${
                     isSubtask ? fetchedTask?.parentTaskId : taskId
                   }`}

--- a/wondrous-app/utils/common.tsx
+++ b/wondrous-app/utils/common.tsx
@@ -126,3 +126,7 @@ export const parseLinks = (links) => {
     mainLink: mainLink,
   };
 };
+
+export const capitalize = (str: string): string => {
+  return str.charAt(0).toUpperCase() + str.slice(1);
+};


### PR DESCRIPTION
Issue - Same message being shown for all entities share

Fix - 

Task Share Message Preview - 

![Screenshot from 2022-07-26 23-48-53](https://user-images.githubusercontent.com/61096193/181082172-61423a9d-c290-4e0c-83eb-7054ac05a5dc.png)

Bounty Share Message Preview - 

![Screenshot from 2022-07-26 23-49-10](https://user-images.githubusercontent.com/61096193/181082236-0ed5797c-1d5e-4d68-b06d-afcfac42537e.png)

Milestone Share Message Preview - 

![Screenshot from 2022-07-26 23-49-01](https://user-images.githubusercontent.com/61096193/181082264-61deffe5-c003-4646-b50c-fa63710e51a9.png)


Proposal Share Message Preview - 

![Screenshot from 2022-07-26 23-49-17](https://user-images.githubusercontent.com/61096193/181082285-d29eff62-7796-4b67-ad4c-d13789a6e320.png)



Wonder Task - https://app.wonderverse.xyz/organization/wonderverse/boards?task=61858563564240933&view=grid&entity=task