### PR TITLE
Issue task templates

### DIFF
--- a/wondrous-app/components/CreateEntity/CreateEntityModal/index.tsx
+++ b/wondrous-app/components/CreateEntity/CreateEntityModal/index.tsx
@@ -1331,19 +1331,22 @@ export const CreateEntityModal = (props: ICreateEntityModal) => {
         ];
 
     const description = JSON.stringify(form.values.description);
+
+    const input = {
+      title: form.values.title,
+      orgId: form.values.orgId,
+      podId: form.values.podId,
+      assigneeId: form.values.assigneeId,
+      reviewerIds: form.values.reviewerIds,
+      rewards: rewards,
+      points: parseInt(form.values.points),
+      name: template_name,
+      description: description,
+    };
+
     createTaskTemplate({
       variables: {
-        input: {
-          title: form.values.title,
-          assigneeId: form.values.assigneeId,
-          reviewerIds: form.values.reviewerIds,
-          rewards: rewards,
-          points: parseInt(form.values.points),
-          name: template_name,
-          description: description,
-          orgId: form.values.orgId,
-          podId: form.values.podId,
-        },
+        input,
       },
     }).catch((err) => {
       console.log(err);

--- a/wondrous-app/graphql/fragments/task.ts
+++ b/wondrous-app/graphql/fragments/task.ts
@@ -443,21 +443,14 @@ export const MilestoneFragment = gql`
 export const TaskTemplateFragment = gql`
   fragment TaskTemplateFragment on TaskTemplate {
     id
-    title
-    createdAt
-    createdBy
     name
+    title
+    type
     orgId
     podId
-    description
-    assignee {
-      username
-      profilePicture
-    }
-    creator {
-      username
-      profilePicture
-    }
+    createdAt
+    createdBy
+    assigneeId
     rewards {
       rewardAmount
       paymentMethodId
@@ -466,6 +459,32 @@ export const TaskTemplateFragment = gql`
       tokenName
       chain
     }
+    assignee {
+      username
+      profilePicture
+    }
+    creator {
+      username
+      profilePicture
+    }
     points
+    description
+  }
+`;
+
+export const TaskTemplateInputFragment = gql`
+  fragment TaskTemplateInputFragment on TaskTemplate {
+    title
+    orgId
+    podId
+    assigneeId
+    reviewerIds
+    rewards {
+      rewardAmount
+      paymentMethodId
+    }
+    points
+    name
+    description
   }
 `;

--- a/wondrous-app/graphql/mutations/task.ts
+++ b/wondrous-app/graphql/mutations/task.ts
@@ -1,7 +1,7 @@
 import { gql } from '@apollo/client';
 import { CommentFragment } from 'graphql/fragments/comments';
 import { MediaFragment } from 'graphql/fragments/media';
-import { BountyFragment, MilestoneFragment, TaskFragment, TaskTemplateFragment } from 'graphql/fragments/task';
+import { BountyFragment, MilestoneFragment, TaskFragment, TaskTemplateInputFragment } from 'graphql/fragments/task';
 
 export const CREATE_TASK = gql`
   mutation createTask($input: TaskInput) {
@@ -15,19 +15,19 @@ export const CREATE_TASK = gql`
 export const CREATE_TASK_TEMPLATE = gql`
   mutation createTaskTemplate($input: TaskTemplateInput) {
     createTaskTemplate(input: $input) {
-      ...TaskTemplateFragment
+      ...TaskTemplateInputFragment
     }
   }
-  ${TaskTemplateFragment}
+  ${TaskTemplateInputFragment}
 `;
 
 export const UPDATE_TASK_TEMPLATE = gql`
   mutation updateTaskTemplate($taskTemplateId: ID!, $input: TaskTemplateInput) {
     updateTaskTemplate(taskTemplateId: $taskTemplateId, input: $input) {
-      ...TaskTemplateFragment
+      ...TaskTemplateInputFragment
     }
   }
-  ${TaskTemplateFragment}
+  ${TaskTemplateInputFragment}
 `;
 
 export const DELETE_TASK_TEMPLATE = gql`


### PR DESCRIPTION
## :pushpin: References

I’ve found that the mutation was using the wrong fragment. After fixing that I got an error with `reviewerIds`. The error says that `Cannot query field \"reviewerIds\" on type \"TaskTemplate\"`  the type we are sending is `TaskTemplateInput`. I think this is a BE bug.

![Screenshot from 2022-08-02 14-48-29](https://user-images.githubusercontent.com/77270324/182402746-979bea6b-df80-48e6-a772-db1696866c17.png)

I’m sending now the correct info and type:

![Screenshot from 2022-08-02 14-51-22](https://user-images.githubusercontent.com/77270324/182402805-4f54c56b-0c1c-4029-8350-40162411329f.png)
![Screenshot from 2022-08-02 14-50-10](https://user-images.githubusercontent.com/77270324/182402811-34bc1eef-e0e6-4613-b774-d9ac2e611da5.png)

🚨 But I’m getting an internal server error. 

I also think this is BE bug since there is no ‘type’ on TaskTemplateInput type

full error log:

```
message: "(psycopg2.errors.UndefinedColumn) column \"type\" of relation \"task_template\" does not exist\nLINE 1: ...payment_method_id, reward_amount, org_id, pod_id, type, poin...\n ^\n\n[SQL: INSERT INTO task_template (created_at, updated_at, description, title, assignee_id, name, deleted_at, created_by, payment_method_id, reward_amount, org_id, pod_id, type, points) VALUES (%(created_at)s, %(updated_at)s, %(description)s, %(title)s, %(assignee_id)s, %(name)s, %(deleted_at)s, %(created_by)s, %(payment_method_id)s, %(reward_amount)s, %(org_id)s, %(pod_id)s, %(type)s, %(points)s) RETURNING task_template.id]\n[parameters: {'created_at': datetime.datetime(2022, 8, 2, 12, 45, 37, 168920, tzinfo=tzutc()), 'updated_at': datetime.datetime(2022, 8, 2, 12, 45, 37, 168936, tzinfo=tzutc()), 'description': '[{\"children\":[{\"text\":\"test\"}],\"type\":\"paragraph\"}]', 'title': 'test', 'assignee_id': None, 'name': 'test', 'deleted_at': None, 'created_by': 53884182738239540, 'payment_method_id': None, 'reward_amount': None, 'org_id': 53883805564403715, 'pod_id': None, 'type': 'task', 'points': None}]\n(Background on this error at: https://sqlalche.me/e/14/f405)"
```

**I think the current changes on the PR should work if the BE works.**