### PR TITLE
feat: truncate submission links

### DIFF
--- a/wondrous-app/components/Common/TaskSubmission/styles.tsx
+++ b/wondrous-app/components/Common/TaskSubmission/styles.tsx
@@ -729,6 +729,13 @@ export const TaskSubmissionLink = styled.a`
 
 export const TaskSubmissionLinkIcon = styled(LinkIcon)``;
 
+export const TaskSubmissionLinkText = styled.p`
+  max-width: 580px;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+`;
+
 export const SubmissionDescription = styled.div`
   && {
     font-size: 15px;

--- a/wondrous-app/components/Common/TaskSubmission/submissionItem.tsx
+++ b/wondrous-app/components/Common/TaskSubmission/submissionItem.tsx
@@ -49,6 +49,7 @@ import {
   TaskSubmissionLink,
   TaskSubmissionLinkIcon,
   TaskSubmissionLinkWrapper,
+  TaskSubmissionLinkText,
 } from './styles';
 import palette from 'theme/palette';
 
@@ -262,7 +263,7 @@ const SubmissionItemLink = ({ links }: { links: [] }) => {
       {links?.map(({ url }, index) => (
         <TaskSubmissionLink key={index} href={url} target="_blank" rel="noopener noreferrer">
           <TaskSubmissionLinkIcon />
-          {url}
+          <TaskSubmissionLinkText>{url}</TaskSubmissionLinkText>
         </TaskSubmissionLink>
       ))}
     </TaskSubmissionLinkWrapper>


### PR DESCRIPTION
Truncate submission links so that they don't overflow

Screenshots - 

Before - 

![image](https://user-images.githubusercontent.com/61096193/183265791-8ddb3dd5-c061-4954-a4bc-8a6ecb3716ba.png)

After - 

![Screenshot from 2022-08-07 02-23-01](https://user-images.githubusercontent.com/61096193/183265794-f46f1033-6016-4b0b-8ab4-a3531b213d4d.png)

Task - https://app.wonderverse.xyz/profile/hiboiz/about?task=61511457161872280&view=grid