### PR TITLE
style: to remove warnings for browser global vars

### DIFF
--- a/wondrous-app/.eslintrc
+++ b/wondrous-app/.eslintrc
@@ -3,6 +3,7 @@
     "ecmaVersion": 2022
   },
   "env": {
+    "browser": true,
     "es2021": true
   },
   "root": true,


### PR DESCRIPTION
We're getting warning for browser global variables like `window` , `document`, and `localStorage`. This update will allow the variables and remove the warning.

https://eslint.org/docs/latest/user-guide/configuring/language-options#specifying-environments