### PR TITLE
Membership page improvements

### DIFF
--- a/wondrous-app/components/Pod/members/index.tsx
+++ b/wondrous-app/components/Pod/members/index.tsx
@@ -1,3 +1,4 @@
+import Link from 'next/link';
 import { useEffect, useState } from 'react';
 import { useLazyQuery, useMutation } from '@apollo/client';
 import { GET_POD_BY_ID, GET_POD_MEMBERSHIP_REQUEST } from 'graphql/queries';
@@ -8,7 +9,6 @@ import { SmallAvatar } from 'components/Common/AvatarList';
 import {
   MemberRequestsList,
   MemberRequestCard,
-  RequestCount,
   RequestCountWrapper,
   RequestCountEmptyState,
   RequestHeader,
@@ -21,9 +21,10 @@ import {
   RequestApproveButton,
   MemberRequestsListEndMessage,
   EmptyMemberRequestsListMessage,
+  MemberProfileLink,
 } from './styles';
 
-const QUERY_LIMIT = 20;
+const QUERY_LIMIT = 3;
 
 const useGetPodMemberRequests = (podId) => {
   const [hasMore, setHasMore] = useState(false);
@@ -140,24 +141,27 @@ function MemberRequests(props) {
             <MemberRequestsList>
               {podUserMembershipRequests?.map((request) => (
                 <MemberRequestCard key={request.id}>
-                  {request.userProfilePicture ? (
-                    <SafeImage
-                      width={28}
-                      height={28}
-                      style={{ width: '28px', height: '28px', borderRadius: '50%' }}
-                      src={request.userProfilePicture}
-                      useNextImage
-                    />
-                  ) : (
-                    <SmallAvatar
-                      id={request.id}
-                      username={request.userUsername}
-                      initials={getUserInitials(request.userUsername)}
-                      style={{ width: '28px', height: '28px' }}
-                    />
-                  )}
-
-                  <MemberName>{request.userUsername}</MemberName>
+                  <Link href={`/profile/${request.userUsername}/about`} passHref>
+                    <MemberProfileLink>
+                      {request.userProfilePicture ? (
+                        <SafeImage
+                          width={28}
+                          height={28}
+                          style={{ width: '28px', height: '28px', borderRadius: '50%' }}
+                          src={request.userProfilePicture}
+                          useNextImage
+                        />
+                      ) : (
+                        <SmallAvatar
+                          id={request.id}
+                          username={request.userUsername}
+                          initials={getUserInitials(request.userUsername)}
+                          style={{ width: '28px', height: '28px' }}
+                        />
+                      )}
+                      <MemberName>{request.userUsername}</MemberName>
+                    </MemberProfileLink>
+                  </Link>
                   <MemberMessage>“{request.message}”</MemberMessage>
                   <RequestActionButtons>
                     <RequestDeclineButton onClick={() => declineRequest(request.userId, request.podId)}>

--- a/wondrous-app/components/Pod/members/index.tsx
+++ b/wondrous-app/components/Pod/members/index.tsx
@@ -23,8 +23,7 @@ import {
   EmptyMemberRequestsListMessage,
 } from './styles';
 
-const QUERY_LIMIT = 3;
-const REFETCH_QUERY_LIMIT = 20;
+const QUERY_LIMIT = 20;
 
 const useGetPodMemberRequests = (podId) => {
   const [hasMore, setHasMore] = useState(false);
@@ -35,7 +34,7 @@ const useGetPodMemberRequests = (podId) => {
     notifyOnNetworkStatusChange: true,
     onCompleted: ({ getPodMembershipRequest }) => {
       // if previousData is undefined, it means this is the initial fetch
-      const limitToRefer = previousData ? REFETCH_QUERY_LIMIT : QUERY_LIMIT;
+      const limitToRefer = previousData ? QUERY_LIMIT : QUERY_LIMIT;
       const updatedDataLength = previousData
         ? getPodMembershipRequest?.length - previousData?.getPodMembershipRequest?.length
         : getPodMembershipRequest?.length;
@@ -99,7 +98,7 @@ function MemberRequests(props) {
       variables: {
         podId,
         offset: podUserMembershipRequests?.length,
-        limit: REFETCH_QUERY_LIMIT,
+        limit: QUERY_LIMIT,
       },
     });
   };

--- a/wondrous-app/components/Pod/members/styles.tsx
+++ b/wondrous-app/components/Pod/members/styles.tsx
@@ -75,13 +75,19 @@ export const MemberRequestCard = styled.div`
   width: 100%;
 `;
 
+export const MemberProfileLink = styled.a`
+  display: flex;
+  align-items: center;
+  text-decoration: none;
+  gap: 12px;
+`;
+
 export const MemberName = styled(Typography)`
   && {
     font-family: 'Space Grotesk';
     font-size: 16px;
     font-weight: 600;
     color: ${palette.white};
-    margin-left: 12px;
   }
 `;
 

--- a/wondrous-app/components/organization/members/index.tsx
+++ b/wondrous-app/components/organization/members/index.tsx
@@ -23,7 +23,7 @@ import {
   EmptyMemberRequestsListMessage,
 } from './styles';
 
-const QUERY_LIMIT = 3;
+const QUERY_LIMIT = 20;
 
 const useGetOrgMemberRequests = (orgId) => {
   const [hasMore, setHasMore] = useState(false);

--- a/wondrous-app/components/organization/members/index.tsx
+++ b/wondrous-app/components/organization/members/index.tsx
@@ -1,3 +1,4 @@
+import Link from 'next/link';
 import { useEffect, useState } from 'react';
 import { useLazyQuery, useMutation } from '@apollo/client';
 import { GET_ORG_FROM_USERNAME, GET_ORG_MEMBERSHIP_REQUEST } from 'graphql/queries';
@@ -8,12 +9,12 @@ import { SmallAvatar } from 'components/Common/AvatarList';
 import {
   MemberRequestsList,
   MemberRequestCard,
-  RequestCount,
   RequestCountWrapper,
   RequestCountEmptyState,
   RequestHeader,
   RequestsContainer,
   ShowMoreButton,
+  MemberProfileLink,
   MemberName,
   MemberMessage,
   RequestActionButtons,
@@ -139,24 +140,27 @@ function MemberRequests(props) {
             <MemberRequestsList>
               {orgUserMembershipRequests?.map((request) => (
                 <MemberRequestCard key={request.id}>
-                  {request.userProfilePicture ? (
-                    <SafeImage
-                      width={28}
-                      height={28}
-                      style={{ width: '28px', height: '28px', borderRadius: '50%' }}
-                      src={request.userProfilePicture}
-                      useNextImage
-                    />
-                  ) : (
-                    <SmallAvatar
-                      id={request.id}
-                      username={request.userUsername}
-                      initials={getUserInitials(request.userUsername)}
-                      style={{ width: '28px', height: '28px' }}
-                    />
-                  )}
-
-                  <MemberName>{request.userUsername}</MemberName>
+                  <Link href={`/profile/${request.userUsername}/about`} passHref>
+                    <MemberProfileLink>
+                      {request.userProfilePicture ? (
+                        <SafeImage
+                          width={28}
+                          height={28}
+                          style={{ width: '28px', height: '28px', borderRadius: '50%' }}
+                          src={request.userProfilePicture}
+                          useNextImage
+                        />
+                      ) : (
+                        <SmallAvatar
+                          id={request.id}
+                          username={request.userUsername}
+                          initials={getUserInitials(request.userUsername)}
+                          style={{ width: '28px', height: '28px' }}
+                        />
+                      )}
+                      <MemberName>{request.userUsername}</MemberName>
+                    </MemberProfileLink>
+                  </Link>
                   <MemberMessage>“{request.message}”</MemberMessage>
                   <RequestActionButtons>
                     <RequestDeclineButton onClick={() => declineRequest(request.userId, request.orgId)}>

--- a/wondrous-app/components/organization/members/index.tsx
+++ b/wondrous-app/components/organization/members/index.tsx
@@ -28,29 +28,25 @@ const QUERY_LIMIT = 20;
 const useGetOrgMemberRequests = (orgId) => {
   const [hasMore, setHasMore] = useState(false);
   const [isInitialFetchForThePage, setIsInitialFetchForThePage] = useState(true); // this state is used to determine if the fetch is from a fetchMore or from route change
-  const [getOrgUserMembershipRequests, { data, fetchMore, previousData, refetch }] = useLazyQuery(
-    GET_ORG_MEMBERSHIP_REQUEST,
-    {
-      fetchPolicy: 'cache-and-network',
-      nextFetchPolicy: 'cache-first',
-      // set notifyOnNetworkStatusChange to true if you want to trigger a rerender whenever the request status updates
-      notifyOnNetworkStatusChange: true,
-      onCompleted: ({ getOrgMembershipRequest }) => {
-        const isPreviousDataValid = previousData && previousData?.getOrgMembershipRequest?.length > 1; // if length of previous data is 1, it is likely a refetch;
+  const [getOrgUserMembershipRequests, { data, fetchMore, previousData }] = useLazyQuery(GET_ORG_MEMBERSHIP_REQUEST, {
+    fetchPolicy: 'cache-and-network',
+    nextFetchPolicy: 'cache-first',
+    // set notifyOnNetworkStatusChange to true if you want to trigger a rerender whenever the request status updates
+    notifyOnNetworkStatusChange: true,
+    onCompleted: ({ getOrgMembershipRequest }) => {
+      const isPreviousDataValid = previousData && previousData?.getOrgMembershipRequest?.length > 1; // if length of previous data is 1, it is likely a refetch;
 
-        const limitToRefer = QUERY_LIMIT;
-        const previousDataLength = previousData?.getOrgMembershipRequest?.length;
-        const currentDataLength = getOrgMembershipRequest?.length;
-        const updatedDataLength = isPreviousDataValid ? currentDataLength - previousDataLength : currentDataLength;
-        if (isInitialFetchForThePage) {
-          setHasMore(currentDataLength >= limitToRefer);
-        } else {
-          updatedDataLength >= 0 && setHasMore(updatedDataLength >= limitToRefer); // updatedDataLength >= 0 means it's not a refetch
-        }
-        console.log({ updatedDataLength, previousDataLength, currentDataLength });
-      },
-    }
-  );
+      const limitToRefer = QUERY_LIMIT;
+      const previousDataLength = previousData?.getOrgMembershipRequest?.length;
+      const currentDataLength = getOrgMembershipRequest?.length;
+      const updatedDataLength = isPreviousDataValid ? currentDataLength - previousDataLength : currentDataLength;
+      if (isInitialFetchForThePage) {
+        setHasMore(currentDataLength >= limitToRefer);
+      } else {
+        updatedDataLength >= 0 && setHasMore(updatedDataLength >= limitToRefer); // updatedDataLength >= 0 means it's not a refetch
+      }
+    },
+  });
   useEffect(() => {
     if (orgId) {
       getOrgUserMembershipRequests({

--- a/wondrous-app/components/organization/members/styles.tsx
+++ b/wondrous-app/components/organization/members/styles.tsx
@@ -74,13 +74,19 @@ export const MemberRequestCard = styled.div`
   width: 100%;
 `;
 
+export const MemberProfileLink = styled.a`
+  display: flex;
+  align-items: center;
+  text-decoration: none;
+  gap: 12px;
+`;
+
 export const MemberName = styled(Typography)`
   && {
     font-family: 'Space Grotesk';
     font-size: 16px;
     font-weight: 600;
     color: ${palette.white};
-    margin-left: 12px;
   }
 `;
 

--- a/wondrous-app/services/apollo.ts
+++ b/wondrous-app/services/apollo.ts
@@ -49,8 +49,8 @@ const cache = new InMemoryCache({
         },
         getOrgFeed: offsetLimitPagination(), // NOTE: https://www.apollographql.com/docs/react/pagination/core-api/#non-paginated-read-functions
         getPodFeed: offsetLimitPagination(),
-        getOrgMembershipRequest: offsetLimitPagination(),
-        getPodMembershipRequest: offsetLimitPagination(),
+        getOrgMembershipRequest: offsetLimitPagination(['orgId']),
+        getPodMembershipRequest: offsetLimitPagination(['podId']),
         getTasksForMilestone: offsetLimitPagination(['milestoneId', 'status']),
         getProposalsUserCanReview: offsetLimitPagination(),
         getSubmissionsUserCanReview: offsetLimitPagination(),


### PR DESCRIPTION
- Increase the initial limit from 3 to 20
- when you approve all members, it says "no more members to approve" even when there are more folks in the queue. Should be to populated with more people automatically.
- when you move from an org's member page to some other page and come back, the show more button seems to disappear the org page and shows only the initial few requests
- user's name and avatar should be clickable and should take to his/her profile page

task - https://app.wonderverse.xyz/pod/60512277337473193/boards?task=64216633255658155&view=grid&entity=task