### PR TITLE
fix: prevent modal close on task status change to inprogress

### DIFF
--- a/wondrous-app/components/Common/TaskSubmission/submission.tsx
+++ b/wondrous-app/components/Common/TaskSubmission/submission.tsx
@@ -44,10 +44,9 @@ function SubmissionButtonWrapper({ onClick = null, buttonText = null, helperText
 }
 
 const inProgressMoveCompleted =
-  ({ handleClose, boardColumns, board }) =>
+  ({ boardColumns, board }) =>
   (data) => {
     const task = data?.updateTaskStatus;
-    handleClose();
     if (boardColumns?.setColumns) {
       const transformedTask = transformTaskToTaskCard(task, {});
       if (board?.entityType && board?.entityType === ENTITIES_TYPES.BOUNTY) {
@@ -190,7 +189,7 @@ export function TaskSubmissions(props) {
   } = props;
   const router = useRouter();
   const [updateTaskStatus] = useMutation(UPDATE_TASK_STATUS, {
-    onCompleted: inProgressMoveCompleted({ handleClose, boardColumns, board }),
+    onCompleted: inProgressMoveCompleted({ boardColumns, board }),
   });
   const [makeSubmission, setMakeSubmission] = useState(false);
   const [submissionToEdit, setSubmissionToEdit] = useState(null);
@@ -207,7 +206,6 @@ export function TaskSubmissions(props) {
         },
       },
     });
-    handleClose();
   };
 
   const handleCancelSubmission = () => {


### PR DESCRIPTION
Loom - https://www.loom.com/share/464819af563a4e84ae7c48a35b5e9271

Task - https://app.wonderverse.xyz/pod/60512277337473193/boards?task=64681641840214849&view=grid&entity=task