### PR TITLE
fix: remove make submission button for completed/archived bounties

### DIFF
--- a/wondrous-app/components/Common/TaskSubmission/submission.tsx
+++ b/wondrous-app/components/Common/TaskSubmission/submission.tsx
@@ -8,6 +8,7 @@ import { useState } from 'react';
 import { delQuery } from 'utils';
 import {
   ENTITIES_TYPES,
+  TASK_STATUS_ARCHIVED,
   TASK_STATUS_DONE,
   TASK_STATUS_IN_PROGRESS,
   TASK_STATUS_IN_REVIEW,
@@ -238,7 +239,9 @@ export function TaskSubmissions(props) {
           fetchedTaskSubmissions={fetchedTaskSubmissions}
           setFilteredSubmissions={setFilteredSubmissions}
         />
-        {isBounty && <SubmissionButtonWrapper onClick={setMakeSubmission} buttonText="Make a submission" />}
+        {isBounty && fetchedTask?.status !== TASK_STATUS_DONE && fetchedTask?.status !== TASK_STATUS_ARCHIVED && (
+          <SubmissionButtonWrapper onClick={setMakeSubmission} buttonText="Make a submission" />
+        )}
         {!isBounty && (
           <>
             <TaskSubmissionsTaskToDo

--- a/wondrous-app/components/CreateEntity/CreateEntityModal/index.tsx
+++ b/wondrous-app/components/CreateEntity/CreateEntityModal/index.tsx
@@ -1301,7 +1301,7 @@ export default function CreateEntityModal(props: ICreateEntityModal) {
       'reviewerIds',
       existingTask?.reviewers?.map((reviewer) => reviewer.id)
     );
-    form.setFieldValue('claimPolicy', existingTask?.claimPolicy);
+    form.setFieldValue('claimPolicy', existingTask?.claimPolicy || null);
     form.setFieldValue('shouldUnclaimOnDueDateExpiry', existingTask?.shouldUnclaimOnDueDateExpiry);
     form.setFieldValue('points', existingTask?.points || null);
     form.setFieldValue('milestoneId', isEmpty(existingTask?.milestoneId) ? null : existingTask?.milestoneId);


### PR DESCRIPTION
## :pushpin: References

- **Wonder issue:**
- https://app.wonderverse.xyz/dashboard?task=65388397235011739&view=grid
- **Related pull-requests:**

## :blue_book: Description
Fixes the issue of removing submission button for completed/archived bounties
Also fixes the issue of claim policy being default open

## :movie_camera: Screenshot or Video

## :cake: Checklist:

- [x] I self-reviewed my changes
- [x] My changes follow the style guide: https://creative-earth-33e.notion.site/TT-Wonder-Style-guide-4702a45133374148953bfcaf584120b7
- [x] I tested my changes in Chrome
