### PR TITLE
fix: only set claim policy to null if task

### DIFF
--- a/wondrous-app/components/Common/TaskApplication/TaskApplicationButton.tsx
+++ b/wondrous-app/components/Common/TaskApplication/TaskApplicationButton.tsx
@@ -3,6 +3,7 @@ import { Claim } from 'components/Icons/claimTask';
 import { useMutation } from '@apollo/client';
 import { SnackbarAlertContext } from 'components/Common/SnackbarAlert';
 import { CREATE_TASK_APPLICATION } from 'graphql/mutations';
+import { white } from 'theme/colors';
 import TaskApplicationModal from './TaskApplicationFormModal';
 import { ButtonPrimary } from '../button';
 
@@ -72,7 +73,13 @@ export default function TaskApplicationButton({ task, title = 'Apply', setIsAppl
         onClick={handleButtonClick}
         disabled={task?.taskApplicationPermissions?.hasUserApplied}
       >
-        <span>{btnTitle}</span>
+        <span
+          style={{
+            color: white,
+          }}
+        >
+          {btnTitle}
+        </span>
       </ButtonPrimary>
     </>
   );

--- a/wondrous-app/components/CreateEntity/CreateEntityModal/index.tsx
+++ b/wondrous-app/components/CreateEntity/CreateEntityModal/index.tsx
@@ -1117,6 +1117,7 @@ export default function CreateEntityModal(props: ICreateEntityModal) {
   const [fileUploadLoading, setFileUploadLoading] = useState(false);
   const isSubtask = parentTaskId !== undefined;
   const isProposal = entityType === ENTITIES_TYPES.PROPOSAL;
+  const isTask = entityType === ENTITIES_TYPES.TASK;
   const orgBoard = useOrgBoard();
   const podBoard = usePodBoard();
   const userBoard = useUserBoard();
@@ -1301,7 +1302,9 @@ export default function CreateEntityModal(props: ICreateEntityModal) {
       'reviewerIds',
       existingTask?.reviewers?.map((reviewer) => reviewer.id)
     );
-    form.setFieldValue('claimPolicy', existingTask?.claimPolicy || null);
+    if (isTask) {
+      form.setFieldValue('claimPolicy', existingTask?.claimPolicy || null);
+    }
     form.setFieldValue('shouldUnclaimOnDueDateExpiry', existingTask?.shouldUnclaimOnDueDateExpiry);
     form.setFieldValue('points', existingTask?.points || null);
     form.setFieldValue('milestoneId', isEmpty(existingTask?.milestoneId) ? null : existingTask?.milestoneId);
@@ -1316,6 +1319,7 @@ export default function CreateEntityModal(props: ICreateEntityModal) {
     existingTask?.points,
     existingTask?.milestoneId,
     existingTask?.labels,
+    isTask,
   ]);
 
   useEffect(() => {


### PR DESCRIPTION
## :pushpin: References

- **Wonder issue:**
- **Related pull-requests:**

## :blue_book: Description
Removes claimPolicy as an input to create entities that do not require it

## :movie_camera: Screenshot or Video

## :cake: Checklist:

- [x] I self-reviewed my changes
- [x] My changes follow the style guide: https://creative-earth-33e.notion.site/TT-Wonder-Style-guide-4702a45133374148953bfcaf584120b7
- [x] I tested my changes in Chrome
