### PR TITLE
Fix docs page per pod

### DIFF
--- a/wondrous-app/components/DocCategoriesSection/DocCategoriesSection.tsx
+++ b/wondrous-app/components/DocCategoriesSection/DocCategoriesSection.tsx
@@ -14,7 +14,7 @@ function DocCategoriesSection({ onItemClick, onOpenDocDialog, docs, category, on
 
   return (
     <Box>
-      <Box display="flex" alignItems="center" mb={2.5} mt={8}>
+      <Box display="flex" alignItems="center" mb={2.5} mt={4}>
         <Box mr={1}>
           <Image src="/images/icons/folder.png" alt="folder icon" width={16} height={14} />
         </Box>

--- a/wondrous-app/components/Pod/docs/docs.tsx
+++ b/wondrous-app/components/Pod/docs/docs.tsx
@@ -29,6 +29,7 @@ const useGetPodDocs = (podId) => {
     variables: {
       podId,
     },
+    fetchPolicy: 'cache-and-network',
   });
 
   const [getPodDocsCategories, { data: categoriesData, loading: loadingCategories }] = useLazyQuery(
@@ -37,6 +38,7 @@ const useGetPodDocs = (podId) => {
       variables: {
         podId,
       },
+      fetchPolicy: 'network-only',
     }
   );
 
@@ -53,7 +55,6 @@ const useGetPodDocs = (podId) => {
       getPodDocsCategories();
     }
   }, [loadingCategories, podId, getPodDocsCategories, categoriesData]);
-
   return {
     docData: docData?.getPodDocuments,
     categoriesData: categoriesData?.getPodDocumentCategories,
@@ -75,7 +76,6 @@ function Docs(props) {
   const [pinned, setPinned] = useState(false);
   const [menuAnchor, setMenuAnchor] = useState(null);
   const openMenu = Boolean(menuAnchor);
-
   const { data: userPermissionsContextData } = useQuery(GET_USER_PERMISSION_CONTEXT, {
     fetchPolicy: 'cache-and-network',
   });
@@ -159,7 +159,7 @@ function Docs(props) {
         </Tooltip>
       )}
 
-      {isEmpty(docData) && (
+      {isEmpty(docData) && isEmpty(categoriesData) && (
         <EmptyStateGeneric
           content={`Welcome to the Documents page for ${podData?.name}. This is your knowledge hub - link high-signal documents to give context to your team members and community.`}
         />

--- a/wondrous-app/components/organization/docs/docs.tsx
+++ b/wondrous-app/components/organization/docs/docs.tsx
@@ -151,11 +151,6 @@ function Docs(props) {
   console.log(orgData);
   return (
     <Wrapper orgData={orgData}>
-      {isEmpty(docData) && (
-        <EmptyStateGeneric
-          content={`Welcome to the Documents page for ${orgData?.name}. This is your knowledge hub - link high-signal documents to give context to your team members and community.`}
-        />
-      )}
       {canEdit && (
         <Tooltip title="Create new doc category" placement="top">
           <Box sx={styles.categoryButtonContainer}>
@@ -164,6 +159,11 @@ function Docs(props) {
             </Box>
           </Box>
         </Tooltip>
+      )}
+      {isEmpty(docData) && isEmpty(categoriesData) && (
+        <EmptyStateGeneric
+          content={`Welcome to the Documents page for ${orgData?.name}. This is your knowledge hub - link high-signal documents to give context to your team members and community.`}
+        />
       )}
       {!isEmpty(pinnedDocs) && (
         <PinnedDocsSection


### PR DESCRIPTION
## :pushpin: References

- **Wonder issue:**
- **Related pull-requests:**

## :blue_book: Description
Fixes some refetch and spacing errors for pod documentation
## :movie_camera: Screenshot or Video

## :cake: Checklist:

- [x] I self-reviewed my changes
- [x] My changes follow the style guide: https://creative-earth-33e.notion.site/TT-Wonder-Style-guide-4702a45133374148953bfcaf584120b7
- [x] I tested my changes in Chrome
