### PR TITLE
feat: add hide submissions

### DIFF
--- a/wondrous-app/components/Common/TaskSubmission/styles.tsx
+++ b/wondrous-app/components/Common/TaskSubmission/styles.tsx
@@ -516,6 +516,22 @@ export const SubmissionFormCancel = styled(ButtonBase)`
   }
 `;
 
+export const HideSubmissionsCheckBoxDiv = styled.div`
+  display: flex;
+  justify-content: flex-start;
+  align-items: center;
+  margin-top: -12px;
+`;
+
+export const HideSubmissionsHelperText = styled(Typography)`
+  && {
+    font-size: 12px;
+    ${({ theme }) => `
+      color: ${theme.palette.white};
+      font-weight: ${theme.typography.fontWeightMedium};
+    `}
+  }
+`;
 export const SubmissionFormSubmit = styled(ButtonGradient)`
   && {
     ${GradientHighlightHorizontal}

--- a/wondrous-app/components/EmptyStateBoards/index.tsx
+++ b/wondrous-app/components/EmptyStateBoards/index.tsx
@@ -75,7 +75,7 @@ function EmptyStateBoards({ status, hidePlaceholder, fullWidth }: Props) {
 
   const orgRole = orgBoard && userPermissionsContext?.orgRoles[board?.orgId];
 
-  const podRole = podBoard && userPermissionsContext?.podRoles[board?.orgId];
+  const podRole = podBoard && userPermissionsContext?.podRoles[board?.podId];
 
   const role = orgRole || podRole;
 
@@ -94,7 +94,6 @@ function EmptyStateBoards({ status, hidePlaceholder, fullWidth }: Props) {
     handleTaskModal();
   };
   const boardTypeTitle = orgBoard ? 'org' : 'pod';
-
   return (
     <>
       <CreateModalOverlay

--- a/wondrous-app/graphql/fragments/task.ts
+++ b/wondrous-app/graphql/fragments/task.ts
@@ -95,6 +95,7 @@ export const TaskFragment = gql`
     claimPolicy
     claimPolicyRoles
     shouldUnclaimOnDueDateExpiry
+    hideSubmissions
   }
 
   ${MediaFragment}
@@ -157,6 +158,7 @@ export const TaskCardFragment = gql`
       canApply
       hasUserApplied
     }
+    hideSubmissions
   }
   ${MediaFragment}
 `;

--- a/wondrous-app/graphql/mutations/task.ts
+++ b/wondrous-app/graphql/mutations/task.ts
@@ -47,6 +47,15 @@ export const UPDATE_TASK = gql`
   ${TaskFragment}
 `;
 
+export const UPDATE_TASK_SHOW_SUBMISSIONS = gql`
+  mutation updateTaskHideSubmissions($taskId: ID!, $hideSubmissions: Boolean!) {
+    updateTaskHideSubmissions(taskId: $taskId, hideSubmissions: $hideSubmissions) {
+      ...TaskFragment
+    }
+  }
+  ${TaskFragment}
+`;
+
 export const COMPLETE_TASK = gql`
   mutation completeTask($taskId: ID!) {
     completeTask(taskId: $taskId) {


### PR DESCRIPTION
## :pushpin: References

- **Wonder issue:**
- https://app.wonderverse.xyz/organization/wonderverse/boards?task=65860987012514064&view=grid&entity=task
- **Related pull-requests:**

## :blue_book: Description
Adds an ability to hide submissions from people who can review a task. This way projects can preserve privacy when submitting. Submitters can only see their own submissions when this is turned on.
## :movie_camera: Screenshot or Video
Logged in as contributor who submitted:
<img width="1191" alt="Screenshot 2022-08-28 at 14 22 08" src="https://user-images.githubusercontent.com/6445805/187098720-366d741e-4eb3-423b-be01-c080339e57c8.png">

Logged in as admin/canReview:
<img width="1193" alt="Screenshot 2022-08-28 at 14 22 31" src="https://user-images.githubusercontent.com/6445805/187098723-d5305db7-f439-4136-84b7-d6f502971b94.png">
## :cake: Checklist:


- [x] I self-reviewed my changes
- [x] My changes follow the style guide: https://creative-earth-33e.notion.site/TT-Wonder-Style-guide-4702a45133374148953bfcaf584120b7
- [x] I tested my changes in Chrome
