### PR TITLE
Update org privacy

### DIFF
--- a/wondrous-app/components/Settings/generalSettings.tsx
+++ b/wondrous-app/components/Settings/generalSettings.tsx
@@ -121,7 +121,7 @@ function GeneralSettingsComponent(props) {
       tooltip: `Public means anyone can see this ${typeText?.toLowerCase()}`,
     },
     [PRIVACY_LEVEL.private]: {
-      title: 'Pod Members Only',
+      title: isPod ? 'Pod Members Only' : 'Org members Only',
       tooltip: `Private means only those with the proper permissions can see this ${typeText?.toLowerCase()}`,
     },
   };
@@ -245,22 +245,20 @@ function GeneralSettingsComponent(props) {
           </GeneralSettingsSocialsBlockWrapper>
         </GeneralSettingsSocialsBlock>
 
-        {isPod && (
-          <div
-            style={{
-              marginTop: '32px',
-            }}
-          >
-            <CreateFormAddDetailsTab>
-              <CreateFormAddDetailsInputLabel>Visibility</CreateFormAddDetailsInputLabel>
-              <TabsVisibility
-                options={tabsVisibilityOptions}
-                selected={tabsVisibilitySelected}
-                onChange={tabsVisibilityHandleOnChange}
-              />
-            </CreateFormAddDetailsTab>
-          </div>
-        )}
+        <div
+          style={{
+            marginTop: '32px',
+          }}
+        >
+          <CreateFormAddDetailsTab>
+            <CreateFormAddDetailsInputLabel>Visibility</CreateFormAddDetailsInputLabel>
+            <TabsVisibility
+              options={tabsVisibilityOptions}
+              selected={tabsVisibilitySelected}
+              onChange={tabsVisibilityHandleOnChange}
+            />
+          </CreateFormAddDetailsTab>
+        </div>
 
         <GeneralSettingsButtonsBlock>
           <GeneralSettingsResetButton onClick={resetChanges}>Cancel changes</GeneralSettingsResetButton>
@@ -537,6 +535,7 @@ function GeneralSettings() {
   const [orgLinks, setOrgLinks] = useState([]);
   const [descriptionText, setDescriptionText] = useState('');
   const [toast, setToast] = useState({ show: false, message: '' });
+  const [isPrivate, setIsPrivate] = useState(null);
   const router = useRouter();
   const { orgId } = router.query;
 
@@ -548,6 +547,7 @@ function GeneralSettings() {
     setDescriptionText(organization.description);
 
     setOrgProfile(organization);
+    setIsPrivate(organization.privacyLevel === PRIVACY_LEVEL.private);
   }
 
   const [getOrgById, { data: getOrgByIdData }] = useLazyQuery(GET_ORG_BY_ID, {
@@ -621,7 +621,7 @@ function GeneralSettings() {
           links,
           name: orgProfile.name,
           description: orgProfile.description,
-          privacyLevel: orgProfile.privacyLevel,
+          privacyLevel: isPrivate ? PRIVACY_LEVEL.private : PRIVACY_LEVEL.public,
           headerPicture: orgProfile.headerPicture,
           profilePicture: orgProfile.profilePicture,
         },
@@ -651,6 +651,8 @@ function GeneralSettings() {
       logoImage={logoImage}
       newProfile={orgProfile}
       resetChanges={resetChanges}
+      isPrivate={isPrivate}
+      setIsPrivate={setIsPrivate}
       saveChanges={saveChanges}
       typeText="DAO"
       setProfile={setOrgProfile}


### PR DESCRIPTION
## :pushpin: References

- **Wonder issue:**
- **Related pull-requests:**

## :blue_book: Description
Adds ability to edit org privacy in settings
## :movie_camera: Screenshot or Video
<img width="819" alt="Screenshot 2022-08-30 at 18 16 19" src="https://user-images.githubusercontent.com/6445805/187571462-96c21c09-b6cc-455d-aea3-e86b505caafc.png">

## :cake: Checklist:


- [x] I self-reviewed my changes
- [x] My changes follow the style guide: https://creative-earth-33e.notion.site/TT-Wonder-Style-guide-4702a45133374148953bfcaf584120b7
- [x] I tested my changes in Chrome
