### PR TITLE
feat ( style fixes ) - style fixes for mission control

### DIFF
--- a/wondrous-app/components/Common/SidebarMain/SidebarMemo.tsx
+++ b/wondrous-app/components/Common/SidebarMain/SidebarMemo.tsx
@@ -114,7 +114,7 @@ const SideBarMemo = ({ orgsList, sidebar, isMobile, handleProfileClick, user, on
               </ButtonIcon>
             </SidebarTooltip>
 
-            <MissionControlIconButton />
+            <MissionControlIconButton isActive={isPageActive(PAGE_PATHNAME.mission_control)} />
 
             <PodsIconButton />
           </ButtonWrapper>

--- a/wondrous-app/components/Common/SidebarMain/index.tsx
+++ b/wondrous-app/components/Common/SidebarMain/index.tsx
@@ -20,7 +20,7 @@ const SideBarComponent = () => {
       isMobile={isMobile}
       sidebar={sidebar}
       handleProfileClick={() => router.push(`/profile/${user.username}/about`)}
-      onLogoClick={() => router.push('/dashboard')}
+      onLogoClick={() => router.push('/explore')}
     />
   );
 };

--- a/wondrous-app/components/Dashboard/wrapper/styles.tsx
+++ b/wondrous-app/components/Dashboard/wrapper/styles.tsx
@@ -26,6 +26,7 @@ export const ContentContainer = styled.div`
 export const Banner = styled.img`
   width: 100%;
   height: 149px;
+  object-fit: cover;
   background: url(${({ img }) => `${img}`});
   position: relative;
   background-size: cover;

--- a/wondrous-app/utils/constants.ts
+++ b/wondrous-app/utils/constants.ts
@@ -620,4 +620,5 @@ export const USER_BOARD_PAGE_TYPES = {
 export const PAGE_PATHNAME = {
   profile_username_about: '/profile/[username]/about',
   explore: '/explore',
+  mission_control: '/mission-control',
 };


### PR DESCRIPTION
## :pushpin: References

- **Wonder issue:**
- **Related pull-requests:**

## :blue_book: Description

Style fixes

- The W logo should go to the explore page not the dashboard
- The top operator photo looks stretched
-  When the mission control button is pressed, it should hold it’s color like how the explore DAOs button does

## :movie_camera: Screenshot or Video

## :cake: Checklist:

- [x] I self-reviewed my changes
- [x] My changes follow the style guide: https://creative-earth-33e.notion.site/TT-Wonder-Style-guide-4702a45133374148953bfcaf584120b7
- [x] I tested my changes in Chrome
