### PR TITLE
Add ability to add tasks with due date in the past

### DIFF
--- a/wondrous-app/components/SingleDatePicker/SingleDatePicker.tsx
+++ b/wondrous-app/components/SingleDatePicker/SingleDatePicker.tsx
@@ -299,7 +299,6 @@ function SingleDatePicker({
                 }}
                 customArrowIcon={<></>}
                 isDayHighlighted={(day) => highlightDay(day)}
-                isDayBlocked={(day) => day.isBefore(todayMoment)}
                 renderCalendarDay={(props) => <CalendarDay {...props} />}
                 hideKeyboardShortcutsPanel
                 renderCalendarInfo={() =>


### PR DESCRIPTION
## :pushpin: References

- **Wonder issue:** N/A
- **Related pull-requests:**

## :blue_book: Description

Add ability to add tasks with due date in the past

## :movie_camera: Screenshot or Video

<img width="561" alt="image" src="https://user-images.githubusercontent.com/2279571/187982561-37cf11b7-3879-484d-ab90-c584a6192943.png">

## :cake: Checklist:

- [x] I self-reviewed my changes
- [x] My changes follow the style guide: https://creative-earth-33e.notion.site/TT-Wonder-Style-guide-4702a45133374148953bfcaf584120b7
- [x] I tested my changes in Chrome
