### PR TITLE
Fix: Missing button text on FireFox

### DIFF
--- a/wondrous-app/components/ListViewAdmin/ColumnEntry.tsx
+++ b/wondrous-app/components/ListViewAdmin/ColumnEntry.tsx
@@ -392,7 +392,7 @@ function ColumnEntry(props: Props) {
                 onClick={btn.action}
                 key={idx}
               >
-                {btn.isCompleted ? btn.isCompletedLabel : btn.label}
+                <span>{btn.isCompleted ? btn.isCompletedLabel : btn.label}</span>
               </Button>
             );
           })}

--- a/wondrous-app/components/ListViewAdmin/styles.tsx
+++ b/wondrous-app/components/ListViewAdmin/styles.tsx
@@ -58,6 +58,10 @@ export const ApproveButton = styled(RequestApproveButton)`
       background: linear-gradient(270deg, ${palette.green30} -5.62%, ${palette.highlightPurple} 103.12%);
     }
   }
+
+  span {
+    z-index: 1;
+  }
 `;
 
 export const DeclineButton = styled(RequestApproveButton)`
@@ -68,6 +72,10 @@ export const DeclineButton = styled(RequestApproveButton)`
     &:hover {
       background: linear-gradient(270deg, ${palette.red300} -5.62%, ${palette.highlightPurple} 103.12%);
     }
+  }
+  
+  span {
+    z-index: 1;
   }
 `;
 


### PR DESCRIPTION
## :pushpin: References

- **Wonder issue:**
https://wondroushq.slack.com/archives/C01R8BNGKJ7/p1662660580896359

- **Related pull-requests:**

## :blue_book: Description
Added z-index to the button text to fix the issue in FF

## :movie_camera: Screenshot or Video
**Before:**
![screen-2022-09-09-14-43-19-yqt6b](https://user-images.githubusercontent.com/1454782/189352595-a15cab9a-bd9e-4e5c-b080-7c62447e1b15.jpg)


**After:**
![ff-fix](https://user-images.githubusercontent.com/1454782/189352387-63d9ac62-8889-4274-94a4-7b46e0052d30.jpg)


## :cake: Checklist:

- [ ] I self-reviewed my changes
- [ ] My changes follow the style guide: https://creative-earth-33e.notion.site/TT-Wonder-Style-guide-4702a45133374148953bfcaf584120b7
- [ ] I tested my changes in Chrome
