### PR TITLE
feat: blur disabled payment methods

### DIFF
--- a/wondrous-app/components/Settings/PaymentMethods/PaymentMethodList.tsx
+++ b/wondrous-app/components/Settings/PaymentMethods/PaymentMethodList.tsx
@@ -26,6 +26,7 @@ import {
   PaymentMethodTokenMetadataWrapper,
   PaymentMethodEmptyStateContainer,
   HelpText,
+  PaymentMethodTokenDetails,
 } from './styles';
 
 const dropdownItemStyle = {
@@ -35,6 +36,8 @@ const dropdownItemStyle = {
 
 function PaymentMethodDisplay(props) {
   const { paymentMethod } = props;
+
+  const isPaymentMethodDisabled = !!paymentMethod?.deactivatedAt;
 
   const [deactivatePaymentMethod] = useMutation(DEACTIVATE_PAYMENT_METHOD, {
     refetchQueries: [GET_PAYMENT_METHODS_FOR_ORG],
@@ -64,7 +67,7 @@ function PaymentMethodDisplay(props) {
     <PaymentMethodDisplayWrapper>
       <PaymentMethodTokenDetailsWrapper>
         <Grid display="flex" alignItems="center" justifyContent="space-between">
-          <Grid display="flex" alignItems="center" gap="27px">
+          <PaymentMethodTokenDetails isDisabled={isPaymentMethodDisabled}>
             <PaymentMethodTokenInfo>
               <PaymentMethodTokenInfoLabel>Token</PaymentMethodTokenInfoLabel>
               <PaymentMethodTokenInfoValue>
@@ -85,7 +88,7 @@ function PaymentMethodDisplay(props) {
                 <PaymentMethodTokenInfoValueText uppercase>{paymentMethod?.symbol}</PaymentMethodTokenInfoValueText>
               </PaymentMethodTokenInfoValue>
             </PaymentMethodTokenInfo>
-          </Grid>
+          </PaymentMethodTokenDetails>
 
           <PaymentMethodActionMenu right="true">
             <Dropdown
@@ -93,7 +96,7 @@ function PaymentMethodDisplay(props) {
                 <TaskMenuIcon fill={palette.black92} fillOnHover={palette.black60} stroke={palette.grey57} />
               )}
             >
-              {paymentMethod?.deactivatedAt && (
+              {isPaymentMethodDisabled && (
                 <DropdownItem
                   key={`payment-method-activate${paymentMethod?.id}`}
                   onClick={handleActivate}
@@ -102,7 +105,7 @@ function PaymentMethodDisplay(props) {
                   Activate
                 </DropdownItem>
               )}
-              {!paymentMethod?.deactivatedAt && (
+              {!isPaymentMethodDisabled && (
                 <DropdownItem
                   key={`payment-method-deactivate${paymentMethod?.id}`}
                   style={dropdownItemStyle}
@@ -116,7 +119,7 @@ function PaymentMethodDisplay(props) {
         </Grid>
 
         {paymentMethod?.tokenAddress && paymentMethod?.tokenAddress !== '0x0000000000000000000000000000000000000000' && (
-          <PaymentMethodTokenInfo>
+          <PaymentMethodTokenInfo isDisabled={isPaymentMethodDisabled}>
             <PaymentMethodTokenInfoLabel>Token Address</PaymentMethodTokenInfoLabel>
             <PaymentMethodTokenInfoValue>
               <PaymentMethodTokenInfoValueText>{paymentMethod?.tokenAddress}</PaymentMethodTokenInfoValueText>
@@ -124,7 +127,7 @@ function PaymentMethodDisplay(props) {
           </PaymentMethodTokenInfo>
         )}
       </PaymentMethodTokenDetailsWrapper>
-      <PaymentMethodTokenMetadataWrapper>
+      <PaymentMethodTokenMetadataWrapper isDisabled={isPaymentMethodDisabled}>
         <Grid display="flex" alignItems="center" gap="9px">
           <CalendarIcon stroke={palette.grey250} />
           <Typography fontSize="12px" color={palette.grey250}>

--- a/wondrous-app/components/Settings/PaymentMethods/styles.tsx
+++ b/wondrous-app/components/Settings/PaymentMethods/styles.tsx
@@ -123,16 +123,25 @@ export const PaymentMethodTokenDetailsWrapper = styled.div`
   border-bottom: 1px solid ${palette.black87};
 `;
 
+export const PaymentMethodTokenDetails = styled.div`
+  display: flex;
+  align-items: center;
+  gap: 27px;
+  filter: ${({ isDisabled }) => (isDisabled ? 'blur(1.5px)' : 'none')};
+`;
+
 export const PaymentMethodTokenMetadataWrapper = styled.div`
   display: flex;
   align-items: center;
   padding-top: 10px;
+  filter: ${({ isDisabled }) => (isDisabled ? 'blur(1.5px)' : 'none')};
 `;
 
 export const PaymentMethodTokenInfo = styled.div`
   display: flex;
   align-items: center;
   gap: 8px;
+  filter: ${({ isDisabled }) => (isDisabled ? 'blur(1.5px)' : 'none')};
 `;
 
 export const PaymentMethodTokenInfoLabel = styled(Typography)`


### PR DESCRIPTION
## :pushpin: References

- **Wonder issue:** N/A
- **Related pull-requests:** N/A

## :blue_book: Description
blurs disabled payment methods in the payment method page

## :movie_camera: Screenshot or Video
![Screenshot from 2022-09-12 02-20-11](https://user-images.githubusercontent.com/61096193/189548382-5598fa04-4505-44d9-893a-aafd53070642.png)

## :cake: Checklist:

- [x] I self-reviewed my changes
- [x] My changes follow the style guide: https://creative-earth-33e.notion.site/TT-Wonder-Style-guide-4702a45133374148953bfcaf584120b7
- [x] I tested my changes in Chrome
