### PR TITLE
reduce overfetching of additional info

### DIFF
--- a/wondrous-app/components/Common/TaskCreatedBy/index.tsx
+++ b/wondrous-app/components/Common/TaskCreatedBy/index.tsx
@@ -21,7 +21,7 @@ export const StyledMention = styled(Typography)`
 
 export function TaskCreatedBy(props) {
   const { router, type, createdBy } = props;
-  const [getUser, { data: getUserData }] = useLazyQuery(GET_USER);
+  const [getUser, { data: getUserData }] = useLazyQuery(GET_USER); // TODO should be reading this from resolver instead
   const isShown = type === ENTITIES_TYPES.MILESTONE || type === ENTITIES_TYPES.BOUNTY;
   useEffect(() => {
     if (isShown) {

--- a/wondrous-app/graphql/fragments/user.ts
+++ b/wondrous-app/graphql/fragments/user.ts
@@ -42,8 +42,6 @@ export const ProfileUserFragment = gql`
     id
     username
     bio
-    firstName
-    lastName
     headerPicture
     activeEthAddress
     profilePicture
@@ -57,5 +55,16 @@ export const ProfileUserFragment = gql`
       orgCount
       podCount
     }
+  }
+`;
+
+export const SmallUserFragment = gql`
+  fragment UserSmall on User {
+    id
+    username
+    headerPicture
+    activeEthAddress
+    profilePicture
+    thumbnailPicture
   }
 `;

--- a/wondrous-app/graphql/queries/org.ts
+++ b/wondrous-app/graphql/queries/org.ts
@@ -61,10 +61,6 @@ export const GET_ORG_USERS = gql`
         firstName
         lastName
         bio
-        additionalInfo {
-          orgCount
-          podCount
-        }
       }
       role {
         id
@@ -162,9 +158,6 @@ export const SEARCH_ORG_USERS = gql`
       username
       profilePicture
       thumbnailPicture
-      additionalInfo {
-        podCount
-      }
       firstName
       lastName
       bio

--- a/wondrous-app/graphql/queries/pod.ts
+++ b/wondrous-app/graphql/queries/pod.ts
@@ -65,10 +65,6 @@ export const GET_POD_USERS = gql`
         firstName
         lastName
         bio
-        additionalInfo {
-          orgCount
-          podCount
-        }
       }
       role {
         permissions

--- a/wondrous-app/graphql/queries/user.ts
+++ b/wondrous-app/graphql/queries/user.ts
@@ -1,8 +1,10 @@
 import { gql } from '@apollo/client';
-import { OrgFragment } from '../fragments/org';
-import { PodFragment } from '../fragments/pod';
-import { TaskCardFragment } from '../fragments/task';
-import { LoggedinUserFragment, LoggedinWaitlistUserFragment, ProfileUserFragment } from '../fragments/user';
+import {
+  LoggedinUserFragment,
+  LoggedinWaitlistUserFragment,
+  ProfileUserFragment,
+  SmallUserFragment,
+} from '../fragments/user';
 
 export const WHOAMI = gql`
   query whoami {
@@ -88,10 +90,10 @@ export const GET_AUTOCOMPLETE_USERS = gql`
 export const GET_USER = gql`
   query getUser($userId: ID!) {
     getUser(userId: $userId) {
-      ...UserProfile
+      ...UserSmall
     }
   }
-  ${ProfileUserFragment}
+  ${SmallUserFragment}
 `;
 
 export const GET_USER_INTERESTS = gql`


### PR DESCRIPTION
## :pushpin: References

- **Wonder issue:**
- **Related pull-requests:**

## :blue_book: Description
Reduce over fetching of additionalInfo when it's not necessary by not always using the userProfileFragment
## :movie_camera: Screenshot or Video
<img width="705" alt="Screen Shot 2022-09-12 at 6 08 34 PM" src="https://user-images.githubusercontent.com/19996922/189785299-01770d96-6432-4643-8d78-d9a4bb6b7e4f.png">

## :cake: Checklist:

- [ ] I self-reviewed my changes
- [ ] My changes follow the style guide: https://creative-earth-33e.notion.site/TT-Wonder-Style-guide-4702a45133374148953bfcaf584120b7
- [ ] I tested my changes in Chrome
