### PR TITLE
Fixed notifications modal

### DIFF
--- a/wondrous-app/components/Notifications/index.tsx
+++ b/wondrous-app/components/Notifications/index.tsx
@@ -166,7 +166,7 @@ function NotificationsBoard({ onlyBoard = false }) {
   return (
     <>
       <NotificationsOverlay onClick={toggleNotifications} style={{ display }} />
-      <div style={{ position: 'relative', zIndex: -1 }}>
+      <div style={{ position: 'relative' }}>
         <StyledBadge
           color="primary"
           hasUnreadNotifications={unreadCount > 0}


### PR DESCRIPTION
## :pushpin: References

- **Wonder issue:**
- **Related pull-requests:**

## :blue_book: Description

Notifications modal is not clickable. Fixed the issue

## :movie_camera: Screenshot or Video

## :cake: Checklist:

- [x] I self-reviewed my changes
- [x] My changes follow the style guide: https://creative-earth-33e.notion.site/TT-Wonder-Style-guide-4702a45133374148953bfcaf584120b7
- [x] I tested my changes in Chrome
