### PR TITLE
feat: Add glow effect on logo when active, on page

### DIFF
--- a/wondrous-app/components/Common/SidebarMain/SidebarMemo.tsx
+++ b/wondrous-app/components/Common/SidebarMain/SidebarMemo.tsx
@@ -1,6 +1,6 @@
+import HelpModal from 'components/Common/HelpModal.jsx';
 import { SafeImage } from 'components/Common/Image';
 import DefaultUserImage from 'components/Common/Image/DefaultUserImage';
-import HelpModal from 'components/Common/HelpModal.jsx';
 import {
   BottomButtonIcon,
   ButtonIcon,
@@ -11,13 +11,13 @@ import {
   DrawerComponent,
   DrawerContainer,
   DrawerList,
-  HeaderLogo,
-  LogoButton,
   NoLogoDAO,
   StyledSettingsIcon,
 } from 'components/Common/SidebarMain/styles';
 import AddDaoButton from 'components/Common/SidebarMainAddDao';
 import ExploreIconButton from 'components/Common/SidebarMainExplore';
+import SidebarMainLogo from 'components/Common/SidebarMainLogo';
+import MissionControlIconButton from 'components/Common/SidebarMainMissionControl';
 import PodsIconButton from 'components/Common/SidebarMainPods';
 import SidebarTooltip from 'components/Common/SidebarMainTooltip';
 import { toolTipStyle } from 'components/Common/SidebarStyles';
@@ -30,7 +30,6 @@ import React, { memo, useState } from 'react';
 import { Org } from 'types/Org';
 import { User } from 'types/User';
 import { PAGE_PATHNAME } from 'utils/constants';
-import MissionControlIconButton from '../SidebarMainMissionControl';
 
 type Props = {
   isMobile: boolean;
@@ -90,11 +89,7 @@ const SideBarMemo = ({ orgsList, sidebar, isMobile, handleProfileClick, user, on
       <HelpModal open={openHelpModal} handleClose={() => setOpenHelpModal(false)} />
       <DrawerContainer>
         <DrawerBlockWrapper>
-          <SidebarTooltip title="Dashboard" id="tour-header-dashboard-icon">
-            <LogoButton onClick={onLogoClick}>
-              <HeaderLogo />
-            </LogoButton>
-          </SidebarTooltip>
+          <SidebarMainLogo key={router.asPath} onClick={onLogoClick} isActive={isPageActive(PAGE_PATHNAME.explore)} />
           <ButtonWrapper>
             <SidebarTooltip title="Profile">
               <ButtonIcon

--- a/wondrous-app/components/Common/SidebarMain/styles.tsx
+++ b/wondrous-app/components/Common/SidebarMain/styles.tsx
@@ -157,20 +157,6 @@ export const DrawerBackButton = styled(BottomButtonIcon)`
   }
 `;
 
-export const LogoButton = styled(ButtonBase)`
-  && {
-    cursor: pointer;
-  }
-`;
-
-export const HeaderLogo = styled(Logo)`
-  width: 41px;
-  height: 31px;
-  path {
-    fill: white;
-  }
-`;
-
 export const ButtonWrapper = styled.div`
   background: ${({ theme }) => theme.palette.black92};
   display: flex;

--- a/wondrous-app/components/Common/SidebarMainLogo/index.tsx
+++ b/wondrous-app/components/Common/SidebarMainLogo/index.tsx
@@ -1,0 +1,23 @@
+import { HeaderLogo, HeaderLogoBlur, HeaderLogoWhite, LogoButton } from 'components/Common/SidebarMainLogo/styles';
+import SidebarTooltip from 'components/Common/SidebarMainTooltip';
+import { useState } from 'react';
+
+const SidebarMainLogo = ({ onClick, isActive }) => {
+  const [clicked, setClicked] = useState(isActive);
+  const activated = clicked || isActive;
+  const handleOnClick = () => {
+    onClick();
+    setClicked(true);
+  };
+  return (
+    <SidebarTooltip title="Explore" id="tour-header-dashboard-icon">
+      <LogoButton onClick={handleOnClick}>
+        <HeaderLogo activated={activated} />
+        <HeaderLogoWhite activated={activated} />
+        <HeaderLogoBlur activated={activated} />
+      </LogoButton>
+    </SidebarTooltip>
+  );
+};
+
+export default SidebarMainLogo;

--- a/wondrous-app/components/Common/SidebarMainLogo/styles.tsx
+++ b/wondrous-app/components/Common/SidebarMainLogo/styles.tsx
@@ -1,0 +1,48 @@
+import { ButtonBase } from '@mui/material';
+import { Logo } from 'components/Common/ci';
+import styled from 'styled-components';
+
+export const LogoButton = styled(ButtonBase)`
+  && {
+    cursor: pointer;
+    position: relative;
+  }
+`;
+
+export const HeaderLogoBlur = styled(Logo)`
+  width: 70px;
+  height: 70px;
+  filter: blur(15px);
+  position: absolute;
+  z-index: 100;
+  opacity: ${({ activated }) => (activated ? 1 : 0)};
+  transition: opacity 0.1s;
+  ${LogoButton}:active & {
+    opacity: 1;
+  }
+`;
+
+export const HeaderLogo = styled(Logo)`
+  width: 41px;
+  height: 31px;
+  opacity: ${({ activated }) => (activated ? 1 : 0)};
+  transition: opacity 0.1s;
+  z-index: 200;
+  ${LogoButton}:active & {
+    opacity: 1;
+  }
+`;
+
+export const HeaderLogoWhite = styled(Logo)`
+  position: absolute;
+  width: 41px;
+  height: 31px;
+  opacity: ${({ activated }) => (activated ? 0 : 1)};
+  transition: opacity 0.1s;
+  path {
+    fill: white;
+  }
+  ${LogoButton}:active & {
+    opacity: 0;
+  }
+`;


### PR DESCRIPTION
## :pushpin: References

- **Wonder issue:** https://app.wonderverse.xyz/organization/wonderverse/boards?task=66277631981519302&entity=task
- **Related pull-requests:** n/a

## :blue_book: Description

Add glow effect on logo when clicked or on "Explore" page.

## :movie_camera: Screenshot or Video

[591ef116-867a-4e29-ae3c-c1ec9f8f6fe0.webm](https://user-images.githubusercontent.com/8164667/190537235-44fc8c5d-4f17-4ad1-b0a9-77d43ce8dda3.webm)

## :cake: Checklist:

- [x] I self-reviewed my changes
- [x] My changes follow the style guide: https://creative-earth-33e.notion.site/TT-Wonder-Style-guide-4702a45133374148953bfcaf584120b7
- [x] I tested my changes in Chrome
