### PR TITLE
fix: autofocus on title

### DIFF
--- a/wondrous-app/components/CreateEntity/CreateEntityModal/index.tsx
+++ b/wondrous-app/components/CreateEntity/CreateEntityModal/index.tsx
@@ -1685,6 +1685,7 @@ export default function CreateEntityModal(props: ICreateEntityModal) {
           error={form.errors?.title}
           onFocus={() => form.setFieldError('title', undefined)}
           data-cy="create-entity-input-title"
+          autoFocus
         />
         <CreateEntityError>{form.errors?.title}</CreateEntityError>
 


### PR DESCRIPTION
## :pushpin: References

- **Wonder issue:** https://app.wonderverse.xyz/organization/wonderverse/boards?task=67256867643982529&entity=task
- **Related pull-requests:** n/a

## :blue_book: Description

Create task modal should auto focus on the title

## :movie_camera: Screenshot or Video

[512a68e2-342d-4351-83e0-24193b148860.webm](https://user-images.githubusercontent.com/8164667/190947557-d5c30b1c-4dba-43ca-9dae-0298ad8e7325.webm)


## :cake: Checklist:

- [ ] I self-reviewed my changes
- [ ] My changes follow the style guide: https://creative-earth-33e.notion.site/TT-Wonder-Style-guide-4702a45133374148953bfcaf584120b7
- [ ] I tested my changes in Chrome
