### PR TITLE
Fix: Observer styling

### DIFF
--- a/wondrous-app/components/Common/AvatarList/index.tsx
+++ b/wondrous-app/components/Common/AvatarList/index.tsx
@@ -7,7 +7,17 @@ import { SafeImage } from '../Image';
 import { SmallAvatarWrapper, SmallAvatarContainer, AvatarListWrapper } from './styles';
 
 export function SmallAvatar(props) {
-  const { avatar = {}, id, username, goTo, initials = '', style = {}, imageWidth = 29, imageHeight = 29 } = props;
+  const {
+    avatar = {},
+    id,
+    username,
+    goTo,
+    initials = '',
+    style = {},
+    imageWidth = 29,
+    imageHeight = 29,
+    border = '',
+  } = props;
 
   // TODO: create this as a service
   const randomColor = '#363636';
@@ -45,9 +55,12 @@ export function SmallAvatar(props) {
         </Box>
       ) : (
         <SmallAvatarWrapper
+          imageWidth={imageWidth}
+          imageHeight={imageHeight}
           randomColor={avatar?.color || randomColor}
           isOwnerOfPod={avatar?.isOwnerOfPod}
           avatarURL={avatar?.url}
+          border={border}
         >
           {avatar.url ? '' : <span>{initials}</span>}
         </SmallAvatarWrapper>

--- a/wondrous-app/components/Common/AvatarList/styles.tsx
+++ b/wondrous-app/components/Common/AvatarList/styles.tsx
@@ -7,11 +7,17 @@ export const SmallAvatarWrapper = styled.div`
   flex-flow: column;
   align-items: center;
   justify-content: center;
-  width: 29px;
-  height: 29px;
+  width: ${(props) => `${props.imageWidth}px` || '29px'};
+  height: ${(props) => `${props.imageHeight}px` || '29px'};
   border-radius: 29px;
   box-shadow: 0 2px solid black;
-  border: ${(props) => (props.isOwnerOfPod ? `2px solid ${palette.highlightBlue}` : '2px solid black')};
+  border: ${(props) => {
+    if (props.border) {
+      return props.border;
+    }
+
+    return props.isOwnerOfPod ? `2px solid ${palette.highlightBlue}` : '2px solid black';
+  }};
   background-color: ${(props) => props.randomColor || palette.highlightBlue};
   ${(props) => (props.avatarURL ? `background: url(${props.avatarURL});` : '')}
   background-position: center;

--- a/wondrous-app/components/Common/TaskViewModal/taskViewModalFields/WatchersField.tsx
+++ b/wondrous-app/components/Common/TaskViewModal/taskViewModalFields/WatchersField.tsx
@@ -86,14 +86,19 @@ function WatchersField({ fetchedTask }: WatchersFieldProps) {
             }
 
             return (
-              <SmallAvatar
-                imageWidth={22}
-                imageHeight={22}
-                key={user.id}
-                initials={user.username}
-                avatar={{ url: user.profilePicture }}
-                style={{ borderRadius: '50%', border: `2px solid ${palette.grey910}` }}
-              />
+              <Tooltip key={user.username} title={user.username} placement="top">
+                <Box ml="-6px" overflow="hidden">
+                  <SmallAvatar
+                    imageWidth={22}
+                    imageHeight={22}
+                    key={user.id}
+                    initials={user.username.substring(0, 2).toUpperCase()}
+                    avatar={{ url: user.profilePicture }}
+                    style={{ borderRadius: '50%', border: `2px solid ${palette.grey910}`, cursor: 'default' }}
+                    border="none"
+                  />
+                </Box>
+              </Tooltip>
             );
           })}
 
@@ -102,9 +107,10 @@ function WatchersField({ fetchedTask }: WatchersFieldProps) {
               <SmallAvatar
                 imageWidth={22}
                 imageHeight={22}
-                initials={currentUser.username}
+                initials={currentUser.username.substring(0, 2).toUpperCase()}
                 avatar={{ url: currentUser.profilePicture }}
-                style={{ borderRadius: '50%', border: `2px solid ${palette.grey99}` }}
+                style={{ borderRadius: '50%', border: `2px solid ${palette.grey99}`, cursor: 'default' }}
+                border="none"
               />
               <Box
                 sx={{


### PR DESCRIPTION
## :pushpin: References

- **Wonder issue:**
- **Related pull-requests:**

## :blue_book: Description
There was some overlap when 2+ people Observe. The "X" to stop observing also gets hidden
![Screen Shot 2022-09-15 at 1 52 28 PM (1)](https://user-images.githubusercontent.com/1454782/191126091-1fb7bf75-e2e8-4ade-99a1-29ca5ccd2bd9.png)

## :movie_camera: Screenshot or Video
https://www.loom.com/share/02e57c3558a7429891a652740daa4bb9

## :cake: Checklist:

- [x] I self-reviewed my changes
- [x] My changes follow the style guide: https://creative-earth-33e.notion.site/TT-Wonder-Style-guide-4702a45133374148953bfcaf584120b7
- [x] I tested my changes in Chrome
