### PR TITLE
Feat/notif on decline collab

### DIFF
--- a/wondrous-app/components/Notifications/index.tsx
+++ b/wondrous-app/components/Notifications/index.tsx
@@ -77,7 +77,7 @@ function NotificationsBoard({ onlyBoard = false }) {
     let notificationLink = `/${snakeToCamel(notification.objectType)}/${notification.objectId}`;
 
     if (notification.objectType === NOTIFICATION_OBJECT_TYPES.collaboration) {
-      const mainPath = notification.type === COLLAB_TYPES.INVITE ? 'organization' : 'collaboration';
+      const mainPath = notification.type === COLLAB_TYPES.APPROVE ? 'collaboration' : 'organization';
       notificationLink = `/${mainPath}/${notification.additionalData.orgUsername}/boards?collabs=${true}${
         notification.additionalData?.addMember && !notification.viewedAt ? `&addMembers=${true}` : ''
       }`;

--- a/wondrous-app/utils/constants.ts
+++ b/wondrous-app/utils/constants.ts
@@ -354,6 +354,7 @@ export const NOTIFICATION_VERBS = {
   task_submit: 'submitted a',
   collab_invite: 'invited you in a',
   collab_approve: 'approved a',
+  collab_decline: 'declined request to join a',
 };
 
 export const NOTIFICATION_OBJECT_TYPES = {
@@ -371,6 +372,7 @@ export const NOTIFICATION_OBJECT_TYPES = {
 export const COLLAB_TYPES = {
   INVITE: 'collab_invite',
   APPROVE: 'collab_approve',
+  DECLINE: 'collab_decline',
 };
 
 export const PRIVACY_LEVEL = {


### PR DESCRIPTION
## :pushpin: References

- **Wonder issue:**
- **Related pull-requests:** https://github.com/wondrous-dev/wondrous-backend/pull/578

## :blue_book: Description

Add notification on org collab request to decline. Receive is the user who initiated the collab request

## :movie_camera: Screenshot or Video

<img width="361" alt="Screenshot 2022-09-20 at 17 47 58" src="https://user-images.githubusercontent.com/22411330/191290258-c9e207f5-25c5-44a4-996f-6f100ba403c0.png">


## :cake: Checklist:

- [ ] I self-reviewed my changes
- [ ] My changes follow the style guide: https://creative-earth-33e.notion.site/TT-Wonder-Style-guide-4702a45133374148953bfcaf584120b7
- [ ] I tested my changes in Chrome
