### PR TITLE
feat: add discussion count

### DIFF
--- a/wondrous-app/components/Common/TaskViewModal/styles.tsx
+++ b/wondrous-app/components/Common/TaskViewModal/styles.tsx
@@ -766,6 +766,12 @@ export const TaskTabText = styled(Typography)`
   }
 `;
 
+export const DiscussionCount = styled.span`
+  background: ${({ isActive }) => (isActive ? '#282828' : '#282828')};
+  padding: 2px 8px;
+  border-radius: 200px;
+`;
+
 export const TaskSectionContent = styled.div`
   padding: 20px 24px;
   background-color: #141414;

--- a/wondrous-app/components/Common/TaskViewModal/taskViewModalFooter.tsx
+++ b/wondrous-app/components/Common/TaskViewModal/taskViewModalFooter.tsx
@@ -13,6 +13,7 @@ import {
   TaskSubmissionTab,
   TaskTabText,
   TaskSectionContent,
+  DiscussionCount,
 } from './styles';
 import { tabs } from './constants';
 import { selectTabsPerType } from './utils';
@@ -108,7 +109,12 @@ const TaskViewModalFooter = forwardRef<HTMLDivElement, Props>((props, ref) => {
           const active = tab === activeTab;
           return (
             <TaskSubmissionTab key={index} isActive={active} onClick={() => setActiveTab(tab)}>
-              <TaskTabText isActive={active}>{tab}</TaskTabText>
+              <TaskTabText isActive={active}>
+                {tab}{' '}
+                {tab === tabs.discussion && (
+                  <DiscussionCount isActive={active}>{fetchedTask?.commentCount}</DiscussionCount>
+                )}
+              </TaskTabText>
             </TaskSubmissionTab>
           );
         })}


### PR DESCRIPTION
## :pushpin: References

- **Wonder issue:** https://app.wonderverse.xyz/organization/wonderverse/boards?task=67256604584575680&entity=task
- **Related pull-requests:** https://github.com/wondrous-dev/wondrous-backend/pull/587

## :blue_book: Description

discussion tab should show number of comments

## :movie_camera: Screenshot or Video

Inactive:
<img width="199" alt="image" src="https://user-images.githubusercontent.com/8164667/192161529-15e7b142-09e9-4ed3-b469-3e88fdc4d0eb.png">

Active:
<img width="186" alt="image" src="https://user-images.githubusercontent.com/8164667/192161534-4f7dd528-cb73-410b-b51c-43091f838d6d.png">


## :cake: Checklist:

- [x] I self-reviewed my changes
- [x] My changes follow the style guide: https://creative-earth-33e.notion.site/TT-Wonder-Style-guide-4702a45133374148953bfcaf584120b7
- [x] I tested my changes in Chrome
