### PR TITLE
Optimization explicit fetch submission count1

### DIFF
--- a/wondrous-app/graphql/fragments/task.ts
+++ b/wondrous-app/graphql/fragments/task.ts
@@ -161,7 +161,6 @@ export const TaskCardFragment = gql`
     totalSubtaskCount
     totalSubmissionsCount
     approvedSubmissionsCount
-    waitingForReviewSubmissionsCount
     points
     taskApplicationPermissions {
       canClaim

--- a/wondrous-app/graphql/queries/task.ts
+++ b/wondrous-app/graphql/queries/task.ts
@@ -137,6 +137,14 @@ export const GET_SUBTASK_COUNT_FOR_TASK = gql`
   }
 `;
 
+export const GET_SUBMISSION_COUNT_FOR_TASK = gql`
+  query getSubmissionCountForTask($taskId: ID!, $status: String) {
+    getSubmissionCountForTask(taskId: $taskId, status: $status) {
+      submissionCount
+    }
+  }
+`;
+
 export const GET_SUBTASKS_FOR_TASK = gql`
   query getSubtasksForTask($taskId: ID!, $limit: Int, $offset: Int, $status: String) {
     getSubtasksForTask(taskId: $taskId, limit: $limit, offset: $offset, status: $status) {


### PR DESCRIPTION
## :pushpin: References

- **Wonder issue:**
- **Related pull-requests:**
- https://github.com/wondrous-dev/wondrous-backend/pull/588

## :blue_book: Description
instead of fetching number of pending submissions on every card, we only fetch it when we actually drop the card in `completed` column to check. And even if that fetch fails, we'd proceed to move the card anyway since it's only a suggestive prompt

## :movie_camera: Screenshot or Video

## :cake: Checklist:

- [ ] I self-reviewed my changes
- [ ] My changes follow the style guide: https://creative-earth-33e.notion.site/TT-Wonder-Style-guide-4702a45133374148953bfcaf584120b7
- [ ] I tested my changes in Chrome
