### PR TITLE
fix: need to click share twice

### DIFF
--- a/wondrous-app/components/Common/Share/index.tsx
+++ b/wondrous-app/components/Common/Share/index.tsx
@@ -13,9 +13,10 @@ interface IShareProps {
     id: string;
     type?: string;
   };
+  className?: Object;
 }
 
-const Share = ({ fetchedTask }: IShareProps) => {
+const Share = ({ fetchedTask, className }: IShareProps) => {
   const { setSnackbarAlertOpen, setSnackbarAlertMessage } = useContext(SnackbarAlertContext);
   const { id, parentTaskId, orgUsername, type } = fetchedTask;
   const entityType = type || ENTITIES_TYPES.PROPOSAL;
@@ -32,7 +33,7 @@ const Share = ({ fetchedTask }: IShareProps) => {
   };
   return (
     <Tooltip title={`Share ${capitalize(entityType)}`} placement="top">
-      <StyledShare onClick={handleOnClick}>
+      <StyledShare onClick={handleOnClick} className={className}>
         <TaskShareIcon />
       </StyledShare>
     </Tooltip>

--- a/wondrous-app/components/Common/TaskViewModal/styles.tsx
+++ b/wondrous-app/components/Common/TaskViewModal/styles.tsx
@@ -178,11 +178,7 @@ export const SubtaskIconWrapper = styled(TaskModalHeaderIconWrapper)`
   cursor: auto;
 `;
 
-export const TaskModalHeaderShare = styled((props) => (
-  <div {...props}>
-    <Share {...props} />
-  </div>
-))`
+export const TaskModalHeaderShare = styled((props) => <Share {...props} />)`
   && {
     width: 32px;
     height: 32px;


### PR DESCRIPTION
## :pushpin: References

- **Wonder issue:** https://app.wonderverse.xyz/organization/wonderverse/boards?task=69203534981104036&entity=task
- **Related pull-requests:** n/a

## :blue_book: Description

Fix the issue where the user needs to click share twice to copy the link.

## :movie_camera: Screenshot or Video

https://user-images.githubusercontent.com/8164667/193963167-b4215f73-70a5-48ce-a168-74a6dc9aa758.mp4

## :cake: Checklist:

- [x] I self-reviewed my changes
- [x] My changes follow the style guide: https://creative-earth-33e.notion.site/TT-Wonder-Style-guide-4702a45133374148953bfcaf584120b7
- [x] I tested my changes in Chrome
