### PR TITLE
feat: clickable pods and contributors

### DIFF
--- a/wondrous-app/components/Pod/wrapper/index.tsx
+++ b/wondrous-app/components/Pod/wrapper/index.tsx
@@ -440,6 +440,7 @@ function Wrapper(props) {
                   </>
                 ))}
                 <HeaderContributors
+                  isInPodPage
                   onClick={() => {
                     setOpen(true);
                     setShowUsers(true);

--- a/wondrous-app/components/organization/wrapper/styles.tsx
+++ b/wondrous-app/components/organization/wrapper/styles.tsx
@@ -352,8 +352,17 @@ export const HeaderContributors = styled.div`
   display: flex;
   justify-content: space-between;
   align-items: center;
+  gap: 6px;
   cursor: pointer;
-  margin-right: 8px;
+  margin-right: 14px;
+  background: ${(props) => (props?.isInPodPage ? palette.grey950 : palette.grey98)};
+  padding: 12px;
+  border-radius: 1000px;
+  transition: background 0.2s ease-in-out;
+
+  :hover {
+    background: ${palette.grey920};
+  }
 `;
 
 export const HeaderContributorsAmount = styled(Typography)`
@@ -363,23 +372,22 @@ export const HeaderContributorsAmount = styled(Typography)`
     line-height: 150%;
     display: flex;
     align-items: center;
-    color: #ffffff;
+    color: ${palette.highlightBlue};
     text-shadow: 0px 4px 4px rgba(0, 0, 0, 0.25);
-    margin-right: 5px;
   }
 `;
 
 export const HeaderContributorsText = styled(HeaderContributorsAmount)`
-  color: #6c6c6c;
+  && {
+    color: ${palette.white};
+  }
 `;
 
 export const HeaderPods = styled(HeaderContributors)``;
 
 export const HeaderPodsAmount = styled(HeaderContributorsAmount)``;
 
-export const HeaderPodsText = styled(HeaderContributorsAmount)`
-  color: #6c6c6c;
-`;
+export const HeaderPodsText = styled(HeaderContributorsText)``;
 
 export const HeaderGr15Sponsor = styled.div``;
 // cardStyles


### PR DESCRIPTION
## :pushpin: References

- **Wonder issue:** https://app.wonderverse.xyz/pod/60512277337473193/boards?task=68015377256285062&view=grid&entity=task
- **Related pull-requests:** N/A

## :blue_book: Description
Make it obvious that pods and contributors are clickable

## :movie_camera: Screenshot or Video
![Screenshot from 2022-10-07 01-51-57](https://user-images.githubusercontent.com/61096193/194410997-d3eed750-7ac9-4aec-8dcf-6b4c5259b136.png)

![Screenshot from 2022-10-07 01-52-04](https://user-images.githubusercontent.com/61096193/194411032-7d581527-e534-4da1-87ab-df445fbc475a.png)

## :cake: Checklist:

- [x] I self-reviewed my changes
- [x] My changes follow the style guide: https://creative-earth-33e.notion.site/TT-Wonder-Style-guide-4702a45133374148953bfcaf584120b7
- [x] I tested my changes in Chrome
