### PR TITLE
duplicate task

### DIFF
--- a/wondrous-app/components/Common/Task/card.tsx
+++ b/wondrous-app/components/Common/Task/card.tsx
@@ -23,8 +23,9 @@ import DropdownItem from 'components/Common/DropdownItem';
 import { PRIVACY_LEVEL, PERMISSIONS } from 'utils/constants';
 import { MakePaymentModal } from 'components/Common/Payment/PaymentModal';
 import { GET_TASK_SUBMISSIONS_FOR_TASK } from 'graphql/queries/task';
-import { useLazyQuery, useQuery } from '@apollo/client';
+import { useLazyQuery, useQuery, useMutation } from '@apollo/client';
 import { GET_USER_PERMISSION_CONTEXT } from 'graphql/queries';
+import { DUPLICATE_TASK } from 'graphql/mutations/task';
 import SmartLink from 'components/Common/SmartLink';
 import { useLocation } from 'utils/useLocation';
 import Tooltip from 'components/Tooltip';
@@ -128,6 +129,20 @@ export function TaskCard({
   const router = useRouter();
   const { data: userPermissionsContextData } = useQuery(GET_USER_PERMISSION_CONTEXT, {
     fetchPolicy: 'cache-and-network',
+  });
+
+  const [duplicateTask, { loading }] = useMutation(DUPLICATE_TASK, {
+    refetchQueries: () => [
+      'getUserTaskBoardTasks',
+      'getPerStatusTaskCountForUserBoard',
+      'getSubtaskCountForTask',
+      'getPerTypeTaskCountForOrgBoard',
+      'getPerTypeTaskCountForPodBoard',
+      'getPerStatusTaskCountForOrgBoard',
+      'getPerStatusTaskCountForPodBoard',
+      'getOrgTaskBoardTasks',
+      'getPodTaskBoardTasks',
+    ],
   });
 
   const userPermissionsContext = userPermissionsContextData?.getUserPermissionContext
@@ -483,6 +498,21 @@ export function TaskCard({
                         color={palette.red800}
                       >
                         Delete {type}
+                      </DropdownItem>
+                    )}
+                    {!isMilestone && (
+                      <DropdownItem
+                        key={`task-menu-duplicate-${id}`}
+                        onClick={() => {
+                          duplicateTask({
+                            variables: {
+                              taskId: id,
+                            },
+                          });
+                        }}
+                        color={palette.white}
+                      >
+                        Duplicate {type}
                       </DropdownItem>
                     )}
                   </Dropdown>

--- a/wondrous-app/components/Common/Task/index.tsx
+++ b/wondrous-app/components/Common/Task/index.tsx
@@ -223,6 +223,7 @@ export function Task(props) {
   });
 
   const canArchive =
+    permissions.includes(Constants.PERMISSIONS.EDIT_TASK) ||
     permissions.includes(Constants.PERMISSIONS.MANAGE_BOARD) ||
     permissions.includes(Constants.PERMISSIONS.FULL_ACCESS) ||
     task?.createdBy === user?.id;

--- a/wondrous-app/graphql/mutations/task.ts
+++ b/wondrous-app/graphql/mutations/task.ts
@@ -268,3 +268,11 @@ export const UPDATE_TASK_OBSERVERS = gql`
     }
   }
 `;
+
+export const DUPLICATE_TASK = gql`
+  mutation duplicateTask($taskId: ID!) {
+    duplicateTask(taskId: $taskId) {
+      title # maybe this should be returning simple response instead?
+    }
+  }
+`;


### PR DESCRIPTION
## :pushpin: References

- **Wonder issue:**
- **Related pull-requests:**
https://github.com/wondrous-dev/wondrous-backend/pull/606

## :blue_book: Description
add option to duplicate task on task card
not an option yet on task view modal
## :movie_camera: Screenshot or Video

## :cake: Checklist:

- [ ] I self-reviewed my changes
- [ ] My changes follow the style guide: https://creative-earth-33e.notion.site/TT-Wonder-Style-guide-4702a45133374148953bfcaf584120b7
- [ ] I tested my changes in Chrome
