### PR TITLE
fix: hide payment ledger bottom action bar when modal is visible

### DIFF
--- a/wondrous-app/components/Settings/Payouts/PayoutTable.tsx
+++ b/wondrous-app/components/Settings/Payouts/PayoutTable.tsx
@@ -306,7 +306,7 @@ const PayoutTable = (props: PayoutTableProps) => {
         </StyledTable>
       </StyledTableContainer>
 
-      <BottomActionBar isVisible={Object.keys(selectedItems)?.length}>
+      <BottomActionBar isVisible={Object.keys(selectedItems)?.length && !showBatchPayModal}>
         <BottomActionBarText>{Object.keys(selectedItems)?.length} selected</BottomActionBarText>
 
         <Grid display="flex" alignItems="center" gap="12px">


### PR DESCRIPTION
## :pushpin: References

- **Wonder issue:** N/A
- **Related pull-requests:** N/A

## :blue_book: Description
Hide payment ledger bottom action bar when modal is visible

## :movie_camera: Screenshot or Video
https://www.loom.com/share/946ca1b097ae4295ac036879aeb98623

## :cake: Checklist:

- [x] I self-reviewed my changes
- [x] My changes follow the style guide: https://creative-earth-33e.notion.site/TT-Wonder-Style-guide-4702a45133374148953bfcaf584120b7
- [x] I tested my changes in Chrome
