### PR TITLE
fix: remove pod link on pod create

### DIFF
--- a/wondrous-app/components/CreateEntity/CreatePodModal.tsx
+++ b/wondrous-app/components/CreateEntity/CreatePodModal.tsx
@@ -210,12 +210,6 @@ function CreatePodModal(props) {
         description: podDescriptionText,
         orgId: org,
         privacyLevel: isPublicEntity ? PRIVACY_LEVEL.public : PRIVACY_LEVEL.private,
-        links: [
-          {
-            url: link,
-            displayName: link,
-          },
-        ],
       };
       if (!title) {
         const newErrors = { ...errors };
@@ -247,7 +241,7 @@ function CreatePodModal(props) {
         general: 'You need the right permissions to create a pod',
       });
     }
-  }, [podDescriptionText, title, org, canCreatePod, errors, link, createPod, isPublicEntity]);
+  }, [podDescriptionText, title, org, canCreatePod, errors, createPod, isPublicEntity]);
 
   const creating = createPodLoading && !createPodError;
   return (
@@ -328,22 +322,6 @@ function CreatePodModal(props) {
         <CreateFormAddDetailsAppearBlock>
           {(showLinkAttachmentSection || showVisibility) && (
             <CreateFormAddDetailsAppearBlockContainer>
-              {showLinkAttachmentSection && (
-                <CreateFormLinkAttachmentBlock
-                  style={{
-                    borderBottom: 'none',
-                  }}
-                >
-                  <CreateFormLinkAttachmentLabel>Link</CreateFormLinkAttachmentLabel>
-                  <InputForm
-                    value={link}
-                    onChange={(e) => setLink(e.target.value)}
-                    margin
-                    placeholder="Enter link URL"
-                    search={false}
-                  />
-                </CreateFormLinkAttachmentBlock>
-              )}
               {showVisibility && (
                 <CreateFormAddDetailsTab>
                   <CreateFormAddDetailsInputLabel>Who can see this pod?</CreateFormAddDetailsInputLabel>

--- a/wondrous-app/components/Settings/generalSettings.tsx
+++ b/wondrous-app/components/Settings/generalSettings.tsx
@@ -52,7 +52,7 @@ const SOCIALS_DATA = [
     type: 'twitter',
   },
   {
-    icon: <DiscordIcon />,
+    icon: <DiscordIcon fill="#ccbbff" />,
     title: 'Discord',
     link: 'https://discord.gg/',
     type: 'discord',

--- a/wondrous-app/components/Settings/profileSettings.tsx
+++ b/wondrous-app/components/Settings/profileSettings.tsx
@@ -62,7 +62,7 @@ const socialsData = [
     type: 'twitter',
   },
   {
-    icon: <DiscordIcon />,
+    icon: <DiscordIcon fill="#ccbbff" />,
     link: 'https://discord.gg/',
     type: 'discord',
   },


### PR DESCRIPTION
## :pushpin: References

- **Wonder issue:**
- **Related pull-requests:**

## :blue_book: Description
Remove pod link on pod create and change Discord icon color for settings
## :movie_camera: Screenshot or Video

## :cake: Checklist:

- [x] I self-reviewed my changes
- [x] My changes follow the style guide: https://creative-earth-33e.notion.site/TT-Wonder-Style-guide-4702a45133374148953bfcaf584120b7
- [x] I tested my changes in Chrome
