### PR TITLE
fix: use network requests to get latest request

### DIFF
--- a/wondrous-app/components/CreateEntity/CreateEntityModal/Helpers/hooks.tsx
+++ b/wondrous-app/components/CreateEntity/CreateEntityModal/Helpers/hooks.tsx
@@ -122,7 +122,9 @@ export const useGetPodGithubIntegrations = (pod) => {
 };
 
 export const useGetPodPullRequests = (pod) => {
-  const [getPodGithubPullRequests, { data: podGithubPullRequestsData }] = useLazyQuery(GET_POD_GITHUB_PULL_REQUESTS);
+  const [getPodGithubPullRequests, { data: podGithubPullRequestsData }] = useLazyQuery(GET_POD_GITHUB_PULL_REQUESTS, {
+    fetchPolicy: 'cache-and-network',
+  });
   useEffect(() => {
     if (pod) {
       getPodGithubPullRequests({


### PR DESCRIPTION
## :pushpin: References

- **Wonder issue:**
- **Related pull-requests:**

## :blue_book: Description
Fixing Github Pull request fetching to do both cache and network requests to get the most updated
## :movie_camera: Screenshot or Video

## :cake: Checklist:

- [x] I self-reviewed my changes
- [x] My changes follow the style guide: https://creative-earth-33e.notion.site/TT-Wonder-Style-guide-4702a45133374148953bfcaf584120b7
- [x] I tested my changes in Chrome
