### PR TITLE
fix: category field, discard modal

### DIFF
--- a/wondrous-app/components/CreateEntity/CreateEntityModal/Helpers/utils/index.tsx
+++ b/wondrous-app/components/CreateEntity/CreateEntityModal/Helpers/utils/index.tsx
@@ -1,20 +1,33 @@
-import { assignIn, assignWith, cloneDeep, isEmpty, isNull, isUndefined, pick, sortBy, uniqBy } from 'lodash';
-import { PRIVACY_LEVEL, CHAIN_TO_CHAIN_DIPLAY_NAME, ENTITIES_TYPES, CATEGORY_LABELS } from 'utils/constants';
-import { hasCreateTaskPermission, transformCategoryFormat, transformMediaFormat } from 'utils/helpers';
-import * as Yup from 'yup';
+import { SafeImage } from 'components/Common/Image';
 import PrivacyMembersIcon from 'components/Icons/privacyMembers.svg';
 import PrivacyPublicIcon from 'components/Icons/privacyPublic.svg';
-import { SafeImage } from 'components/Common/Image';
-import { plainTextToRichText, deserializeRichText } from 'components/RichText';
+import { deserializeRichText, plainTextToRichText } from 'components/RichText';
 import { FormikValues } from 'formik';
+import assignIn from 'lodash/assignIn';
+import assignWith from 'lodash/assignWith';
+import cloneDeep from 'lodash/cloneDeep';
+import isDate from 'lodash/isDate';
+import isEmpty from 'lodash/isEmpty';
+import isEqual from 'lodash/isEqual';
+import isNull from 'lodash/isNull';
+import isObject from 'lodash/isObject';
+import isUndefined from 'lodash/isUndefined';
+import pick from 'lodash/pick';
+import pickBy from 'lodash/pickBy';
+import sortBy from 'lodash/sortBy';
+import uniqBy from 'lodash/uniqBy';
+import { Dispatch, SetStateAction } from 'react';
+import { CATEGORY_LABELS, CHAIN_TO_CHAIN_DIPLAY_NAME, ENTITIES_TYPES, PRIVACY_LEVEL } from 'utils/constants';
+import { hasCreateTaskPermission, transformCategoryFormat, transformMediaFormat } from 'utils/helpers';
+import * as Yup from 'yup';
 import {
-  useCreateTask,
-  useUpdateTask,
-  useCreateMilestone,
-  useUpdateMilestone,
   useCreateBounty,
-  useUpdateBounty,
+  useCreateMilestone,
+  useCreateTask,
   useCreateTaskProposal,
+  useUpdateBounty,
+  useUpdateMilestone,
+  useUpdateTask,
   useUpdateTaskProposal,
 } from '../hooks';
 
@@ -410,4 +423,15 @@ export interface ICreateEntityModal {
   setEntityType?: Function;
   formValues?: FormikValues;
   status?: string;
+  setFormDirty?: Dispatch<SetStateAction<boolean>>;
 }
+
+export const formDirty = (form: FormikValues): boolean => {
+  const { initialValues, values } = form;
+  const excludedFields = ['orgId'];
+  const pickByValKey = (val, key) =>
+    !excludedFields.includes(key) && val && (isObject(val) && !isDate(val) ? !isEmpty(val) : val);
+  const updatedInitialValues = pickBy(initialValues, pickByValKey);
+  const updatedValues = pickBy(values, pickByValKey);
+  return !isEqual(updatedInitialValues, updatedValues);
+};

--- a/wondrous-app/components/CreateEntity/CreateEntityModal/Helpers/utils/index.tsx
+++ b/wondrous-app/components/CreateEntity/CreateEntityModal/Helpers/utils/index.tsx
@@ -267,7 +267,7 @@ export const entityTypeData = {
       chooseGithubIssue: false,
       parentTaskId: null,
       priority: null,
-      categories: [],
+      categories: null,
     },
   },
   [ENTITIES_TYPES.MILESTONE]: {
@@ -285,7 +285,7 @@ export const entityTypeData = {
       privacyLevel: privacyOptions.public.value,
       mediaUploads: [],
       priority: null,
-      categories: [],
+      categories: null,
     },
   },
   [ENTITIES_TYPES.BOUNTY]: {
@@ -315,7 +315,7 @@ export const entityTypeData = {
       privacyLevel: privacyOptions.public.value,
       mediaUploads: [],
       priority: null,
-      categories: [],
+      categories: null,
     },
   },
   [ENTITIES_TYPES.PROPOSAL]: {
@@ -333,7 +333,7 @@ export const entityTypeData = {
       labelIds: null,
       privacyLevel: privacyOptions.public.value,
       mediaUploads: [],
-      categories: [],
+      categories: null,
     },
   },
 };
@@ -348,7 +348,7 @@ export const initialValues = ({ entityType, existingTask = null, initialPodId = 
       ...existingTask,
       description,
       mediaUploads: transformMediaFormat(existingTask?.media),
-      categories: transformCategoryFormat(existingTask?.categories),
+      categories: isEmpty(existingTask?.categories) ? null : transformCategoryFormat(existingTask?.categories),
       reviewerIds: isEmpty(existingTask?.reviewers) ? null : existingTask.reviewers.map((i) => i.id),
       rewards: existingTask?.rewards?.map(({ rewardAmount, paymentMethodId }) => ({ rewardAmount, paymentMethodId })),
       labelIds: isEmpty(existingTask?.labels) ? null : existingTask.labels.map((i) => i.id),

--- a/wondrous-app/components/CreateEntity/CreateEntityModal/index.tsx
+++ b/wondrous-app/components/CreateEntity/CreateEntityModal/index.tsx
@@ -250,7 +250,7 @@ export default function CreateEntityModal(props: ICreateEntityModal) {
         title: values?.githubPullRequest?.label,
         url: values?.githubPullRequest?.url,
       };
-      const categories = values?.categories.map((category) => category.id || category);
+      const categories = values?.categories?.map((category) => category.id || category);
       const { chooseGithubIssue, chooseGithubPullRequest, githubIssue, githubRepo, recurringSchema, ...finalValues } =
         values;
       const input = {
@@ -1409,17 +1409,29 @@ export default function CreateEntityModal(props: ICreateEntityModal) {
             <CreateEntityLabel>Category</CreateEntityLabel>
           </CreateEntityLabelWrapper>
           <CreateEntitySelectWrapper>
-            <DropdownSearch
-              label="Select Category"
-              searchPlaceholder="Search categories"
-              options={categoriesData}
-              value={filterCategoryValues(form.values.categories)}
-              onChange={(categories) => {
-                form.setFieldValue('categories', [...categories]);
-              }}
-              disabled={formValues?.categories}
-              onClose={() => {}}
-            />
+            {form.values.categories !== null && (
+              <DropdownSearch
+                label="Select Category"
+                searchPlaceholder="Search categories"
+                options={categoriesData}
+                value={filterCategoryValues(form.values.categories)}
+                onChange={(categories) => {
+                  form.setFieldValue('categories', [...categories]);
+                }}
+                disabled={formValues?.categories}
+                onClose={() => {}}
+              />
+            )}
+            {form.values.categories == null && (
+              <CreateEntityLabelAddButton
+                onClick={() => {
+                  form.setFieldValue('categories', []);
+                }}
+              >
+                <CreateEntityAddButtonIcon />
+                <CreateEntityAddButtonLabel>Add</CreateEntityAddButtonLabel>
+              </CreateEntityLabelAddButton>
+            )}
           </CreateEntitySelectWrapper>
         </CreateEntityLabelSelectWrapper>
 

--- a/wondrous-app/components/CreateEntity/CreateEntityModal/index.tsx
+++ b/wondrous-app/components/CreateEntity/CreateEntityModal/index.tsx
@@ -94,6 +94,7 @@ import {
   CreateEntityPaymentMethodItem,
   CreateEntityTextfieldInputPointsComponent,
   CreateEntityTextfieldInputRewardComponent,
+  formDirty,
 } from './Helpers';
 import {
   CreateEntityAddButtonIcon,
@@ -160,7 +161,7 @@ import TaskTemplatePicker from './TaskTemplatePicker';
 import GR15DEICreateSelector from '../Initiatives/GR15DEI';
 
 export default function CreateEntityModal(props: ICreateEntityModal) {
-  const { entityType, handleClose, cancel, existingTask, parentTaskId, formValues, status } = props;
+  const { entityType, handleClose, cancel, existingTask, parentTaskId, formValues, status, setFormDirty } = props;
   const [fileUploadLoading, setFileUploadLoading] = useState(false);
   const isSubtask =
     parentTaskId !== undefined || (existingTask?.parentTaskId !== undefined && existingTask?.parentTaskId !== null);
@@ -585,6 +586,10 @@ export default function CreateEntityModal(props: ICreateEntityModal) {
   const subTasks = useGetSubtasksForTask({ taskId: existingTask?.id, status: TASK_STATUS_TODO });
   const hasSubTasks = subTasks?.data?.length > 0;
   const canTurnIntoBounty = !hasSubTasks && !isSubtask && existingTask?.type === ENTITIES_TYPES.TASK;
+
+  useEffect(() => {
+    setFormDirty(formDirty(form));
+  }, [form, setFormDirty]);
 
   return (
     <CreateEntityForm onSubmit={form.handleSubmit} fullScreen={fullScreen} data-cy="modal-create-entity">

--- a/wondrous-app/components/CreateEntity/index.tsx
+++ b/wondrous-app/components/CreateEntity/index.tsx
@@ -41,23 +41,10 @@ interface ICreateEntity {
 export function CreateEntity(props: ICreateEntity) {
   const { open, entityType, handleCloseModal, isTaskProposal } = props;
   const [discard, setDiscard] = useState(false);
-  const handleCloseForm = () => setDiscard(true);
+  const [formDirty, setFormDirty] = useState(false);
+  const handleCloseForm = () => (formDirty ? setDiscard(true) : handleCloseModal());
   const forNewModal = [ENTITIES_TYPES.TASK, ENTITIES_TYPES.MILESTONE, ENTITIES_TYPES.BOUNTY].includes(entityType);
-  if (isTaskProposal) {
-    return (
-      <>
-        <CreateEntityDiscardTask
-          open={discard}
-          onClose={setDiscard}
-          onCloseFormModal={handleCloseModal}
-          entityType={entityType}
-        />
-        <CreateFormModalOverlay open={open} onClose={handleCloseForm}>
-          <CreateEntityModal {...props} />
-        </CreateFormModalOverlay>
-      </>
-    );
-  }
+  const showNewModal = forNewModal || isTaskProposal;
   return (
     <>
       <CreateEntityDiscardTask
@@ -67,7 +54,7 @@ export function CreateEntity(props: ICreateEntity) {
         entityType={entityType}
       />
       <CreateFormModalOverlay open={open} onClose={handleCloseForm}>
-        {forNewModal ? <CreateEntityModal {...props} /> : <CreatePodModal {...props} />}
+        {showNewModal ? <CreateEntityModal {...props} setFormDirty={setFormDirty} /> : <CreatePodModal {...props} />}
       </CreateFormModalOverlay>
     </>
   );

--- a/wondrous-app/components/CreateEntityDiscardTask/index.tsx
+++ b/wondrous-app/components/CreateEntityDiscardTask/index.tsx
@@ -31,6 +31,7 @@ const CreateEntityDiscardTask = ({ open, onClose, onCloseFormModal, entityType }
       footerRight={footerRight}
       maxWidth={560}
       open={open}
+      alignCenter
     >
       <Typography sx={{ color: 'white', textAlign: 'center' }}>
         Are you sure you want to discard the changes to your current {entityType}?


### PR DESCRIPTION
## :pushpin: References

- **Wonder issue:**
1. https://app.wonderverse.xyz/organization/wonderverse/boards?task=70454624532824833&entity=task
2. https://app.wonderverse.xyz/organization/wonderverse/boards?task=70455003371799298&entity=task
- **Related pull-requests:** n/a

## :blue_book: Description

Fixes the following:
1. Discard task should only pop-up if you have entered something into the task
2. Category should default closed

## :movie_camera: Screenshot or Video


https://user-images.githubusercontent.com/8164667/198181069-84bbc8c2-15a1-49a5-b3ae-5c7b3e1b5bd6.mp4



## :cake: Checklist:

- [ ] I self-reviewed my changes
- [ ] My changes follow the style guide: https://creative-earth-33e.notion.site/TT-Wonder-Style-guide-4702a45133374148953bfcaf584120b7
- [ ] I tested my changes in Chrome
