### PR TITLE
fix: remove submission count from task explore

### DIFF
--- a/wondrous-app/components/Common/BountyBoard/index.tsx
+++ b/wondrous-app/components/Common/BountyBoard/index.tsx
@@ -11,7 +11,7 @@ import {
   BoardsCardBodyDescription,
   BoardsCardMedia,
 } from 'components/Common/Boards/styles';
-import { PRIVACY_LEVEL, TASK_STATUS_DONE, TASK_STATUS_TODO } from 'utils/constants';
+import { BOUNTY_TYPE, PRIVACY_LEVEL, TASK_STATUS_DONE, TASK_STATUS_TODO } from 'utils/constants';
 import CommentsIcon from 'components/Icons/comments';
 import { SafeImage } from 'components/Common/Image';
 import { SubtaskDarkIcon } from 'components/Icons/subtask';
@@ -140,7 +140,9 @@ export default function Board({ tasks, handleCardClick = (bounty) => {}, display
                     />
                   </BoardsCardMedia>
                 ) : null}
-                <SubmissionsCount total={bounty.totalSubmissionsCount} approved={bounty.approvedSubmissionsCount} />
+                {bounty?.type === BOUNTY_TYPE && (
+                  <SubmissionsCount total={bounty.totalSubmissionsCount} approved={bounty.approvedSubmissionsCount} />
+                )}
               </BoardsCardBody>
               <BoardsCardFooter>
                 {bounty?.podName && !displayOrg && (


### PR DESCRIPTION
## :pushpin: References

- **Wonder issue:**
- **Related pull-requests:**

## :blue_book: Description
Remove submission count for non bounties on explore
## :movie_camera: Screenshot or Video
<img width="1232" alt="Screenshot 2022-10-26 at 21 40 26" src="https://user-images.githubusercontent.com/6445805/198192951-88296d16-342a-4bf6-9070-8a920d46a716.png">

## :cake: Checklist:

- [x] I self-reviewed my changes
- [x] My changes follow the style guide: https://creative-earth-33e.notion.site/TT-Wonder-Style-guide-4702a45133374148953bfcaf584120b7
- [x] I tested my changes in Chrome
