### PR TITLE
feat: show archived pods in the pod page

### DIFF
--- a/wondrous-app/components/organization/pods/PodItem/index.tsx
+++ b/wondrous-app/components/organization/pods/PodItem/index.tsx
@@ -3,7 +3,7 @@ import RolePill from 'components/Common/RolePill';
 import PodIcon from 'components/Icons/podIcon';
 import MemberIcon from 'components/Icons/Sidebar/people.svg';
 import { UNARCHIVE_POD } from 'graphql/mutations';
-import { GET_ORG_ARCHIVED_PODS, GET_ORG_PODS, GET_USER_PODS } from 'graphql/queries';
+import { GET_ORG_ARCHIVED_PODS, GET_ORG_FROM_USERNAME, GET_ORG_PODS, GET_USER_PODS } from 'graphql/queries';
 import { useOrgBoard } from 'utils/hooks';
 import {
   PodDescriptionText,
@@ -23,7 +23,7 @@ const PodItem = (props) => {
 
   const { userPermissionsContext } = useOrgBoard() || {};
   const [unarchivePod] = useMutation(UNARCHIVE_POD, {
-    refetchQueries: [GET_ORG_PODS, GET_USER_PODS, GET_ORG_ARCHIVED_PODS],
+    refetchQueries: [GET_ORG_PODS, GET_USER_PODS, GET_ORG_ARCHIVED_PODS, GET_ORG_FROM_USERNAME],
   });
 
   const podId = podData?.id;

--- a/wondrous-app/components/organization/pods/PodItem/styles.tsx
+++ b/wondrous-app/components/organization/pods/PodItem/styles.tsx
@@ -1,4 +1,4 @@
-import { Typography } from '@mui/material';
+import { Button, Typography } from '@mui/material';
 import styled from 'styled-components';
 import palette from 'theme/palette';
 
@@ -55,6 +55,50 @@ export const PodItemIconWrapper = styled.div`
   border-radius: 1000px;
   background: ${({ bgColor }) => bgColor || palette.black85};
   display: flex;
+`;
+
+export const PodItemUnarchiveButton = styled(Button)`
+  && {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    background: ${palette.background.default};
+    color: ${palette.white};
+    font-size: 14px;
+    border-radius: 6px;
+    padding: 8px;
+    transition: background 0.2s ease-in-out;
+
+    &::before {
+      content: '';
+      display: block;
+      height: 100%;
+      width: 100%;
+      position: absolute;
+      top: 0;
+      left: 0;
+      background: linear-gradient(
+        232.77deg,
+        ${palette.highlightBlue} 18.39%,
+        ${palette.highlightPurple} 86.24%,
+        ${palette.blue20} 161.54%
+      );
+      mask: linear-gradient(${palette.white} 0 0) content-box, linear-gradient(${palette.white} 0 0);
+      mask-composite: xor;
+      mask-composite: exclude;
+      padding: 2px;
+      border-radius: 6px;
+    }
+
+    &:hover {
+      background: linear-gradient(
+        232.77deg,
+        ${palette.highlightBlue} 18.39%,
+        ${palette.highlightPurple} 86.24%,
+        ${palette.blue20} 161.54%
+      );
+    }
+  }
 `;
 
 export const PodItemStatsContainer = styled.div`

--- a/wondrous-app/components/organization/pods/constants.tsx
+++ b/wondrous-app/components/organization/pods/constants.tsx
@@ -2,4 +2,5 @@ export enum PodView {
   ALL_PODS = 0,
   PODS_USER_IS_MEMBER_OF = 1,
   PODS_USER_IS_NOT_MEMBER_OF = 2,
+  ARCHIVED_PODS = 3,
 }

--- a/wondrous-app/graphql/queries/org.ts
+++ b/wondrous-app/graphql/queries/org.ts
@@ -194,6 +194,28 @@ export const GET_ORG_PODS = gql`
   }
 `;
 
+export const GET_ORG_ARCHIVED_PODS = gql`
+  query getOrgArchivedPods($orgId: String) {
+    getOrgArchivedPods(orgId: $orgId) {
+      id
+      name
+      username
+      description
+      privacyLevel
+      headerPicture
+      profilePicture
+      thumbnailPicture
+      createdBy
+      createdAt
+      orgId
+      tags
+      contributorCount
+      tasksCompletedCount
+      color
+    }
+  }
+`;
+
 export const SEARCH_ORG_USERS = gql`
   query searchOrgUsers($orgIds: [ID], $searchString: String!, $limit: Int, $offset: Int) {
     searchOrgUsers(orgIds: $orgIds, searchString: $searchString, limit: $limit, offset: $offset) {


### PR DESCRIPTION
## :pushpin: References

- **Wonder issue:** https://app.wonderverse.xyz/organization/wonderverse/boards?task=71229169709613998&view=grid&entity=task
- **Related pull-requests:** https://github.com/wondrous-dev/wondrous-backend/pull/629

## :blue_book: Description
add archived pods tab in the pod page

## :movie_camera: Screenshot or Video
https://www.loom.com/share/ebadbb83ae664944b9258c0e2ce9c90a

## :cake: Checklist:

- [x] I self-reviewed my changes
- [x] My changes follow the style guide: https://creative-earth-33e.notion.site/TT-Wonder-Style-guide-4702a45133374148953bfcaf584120b7
- [x] I tested my changes in Chrome
