### PR TITLE
feat: add discord user display when connected

### DIFF
--- a/wondrous-app/components/ProfileInfo/ProfileInfo.tsx
+++ b/wondrous-app/components/ProfileInfo/ProfileInfo.tsx
@@ -18,6 +18,7 @@ import DefaultUserImage from 'components/Common/Image/DefaultUserImage';
 import { GR15DEILogo } from 'components/Common/IntiativesModal/GR15DEIModal/GR15DEILogo';
 import GR15DEIModal from 'components/Common/IntiativesModal/GR15DEIModal';
 import ChooseEntityToCreate from 'components/CreateEntity';
+import { removeUrlStart } from 'utils/helpers';
 import styles, {
   ProfileInfoWrapper,
   ProfileInfoContainer,
@@ -44,6 +45,30 @@ const SOCIAL_ICONS = {
   [SOCIAL_OPENSEA]: OpenSeaIcon,
 };
 
+const parseUserProfileInfo = (socials, userProfile) => {
+  let hasDiscordSocial = false;
+
+  const newSocials = socials.map(({ url, type }) => {
+    if (type === SOCIAL_MEDIA_DISCORD) {
+      hasDiscordSocial = true;
+    } else if (type === SOCIAL_MEDIA_TWITTER) {
+      if (userProfile?.userInfo?.twitterUsername) {
+        return {
+          url: `https://twitter.com/${userProfile?.userInfo?.twitterUsername}`,
+          type: SOCIAL_MEDIA_TWITTER,
+        };
+      }
+    }
+  });
+  if (!hasDiscordSocial && userProfile?.userInfo?.discordUsername) {
+    newSocials.push({
+      url: null,
+      type: SOCIAL_MEDIA_DISCORD,
+    });
+  }
+  return newSocials;
+};
+
 function ProfileInfo({ userProfile }) {
   const user = useMe();
   const [openGR15Modal, setOpenGR15Modal] = useState(false);
@@ -57,6 +82,7 @@ function ProfileInfo({ userProfile }) {
     ? user?.checkIsGr15Contributor?.isGr15Contributor
     : userProfile?.checkIsGr15Contributor?.isGr15Contributor;
 
+  const newSocials = parseUserProfileInfo(social, userProfile);
   return (
     <ProfileInfoWrapper>
       <ChooseEntityToCreate />
@@ -133,17 +159,40 @@ function ProfileInfo({ userProfile }) {
               <ProfileInfoIcon>
                 <ProfileInfoLinkIcon />
               </ProfileInfoIcon>
-              <ProfileInfoIcon>{formatLinkDisplay(mainLink)}</ProfileInfoIcon>
+              <ProfileInfoIcon>{removeUrlStart(mainLink?.url)}</ProfileInfoIcon>
             </ProfileInfoMainLink>
           </ProfileInfoLink>
         )}
-        {social.map(({ url, type }) => {
-          if (!url) return null;
+        {}
+        {newSocials.map(({ url, type }) => {
           const SocialIcon = SOCIAL_ICONS[type];
+          if (type === SOCIAL_MEDIA_DISCORD && userProfile?.userInfo?.discordUsername) {
+            return (
+              <ProfileInfoLink
+                key={url}
+                href={url}
+                target="_blank"
+                style={{
+                  textDecoration: 'none',
+                }}
+              >
+                <ProfileInfoIcon
+                  style={{
+                    marginRight: '8px',
+                  }}
+                >
+                  <SocialIcon fill="#ccbbff" />
+                </ProfileInfoIcon>
+                <ProfileInfoIcon>{`${userProfile?.userInfo?.discordUsername}#${userProfile?.userInfo?.discordDiscriminator}`}</ProfileInfoIcon>
+              </ProfileInfoLink>
+            );
+          }
+          if (!url) return null;
+
           return (
             <ProfileInfoLink key={url} href={url} target="_blank">
               <ProfileInfoIcon>
-                <SocialIcon />
+                <SocialIcon fill="#ccbbff" />
               </ProfileInfoIcon>
             </ProfileInfoLink>
           );

--- a/wondrous-app/components/Settings/profileSettings.tsx
+++ b/wondrous-app/components/Settings/profileSettings.tsx
@@ -57,16 +57,6 @@ const discordUrl = getDiscordUrl();
 
 const socialsData = [
   {
-    icon: <TwitterPurpleIcon />,
-    link: 'https://twitter.com/',
-    type: 'twitter',
-  },
-  {
-    icon: <DiscordIcon fill="#ccbbff" />,
-    link: 'https://discord.gg/',
-    type: 'discord',
-  },
-  {
     icon: <OpenSeaIcon />,
     link: 'https://opensea.io/',
     type: 'opensea',
@@ -116,7 +106,11 @@ function SettingsLinks({ links, setLinks }) {
   };
   return (
     <>
-      <GeneralSettingsSocialsBlock>
+      <GeneralSettingsSocialsBlock
+        style={{
+          paddingTop: '0',
+        }}
+      >
         <LabelBlock>Socials</LabelBlock>
         <GeneralSettingsSocialsBlockWrapper>
           {socialsData.map((item) => {

--- a/wondrous-app/graphql/fragments/user.ts
+++ b/wondrous-app/graphql/fragments/user.ts
@@ -12,6 +12,7 @@ export const LoggedinUserFragment = gql`
     userInfo {
       email
       discordUsername
+      discordDiscriminator
       twitterUsername
       promotionTweet
     }
@@ -53,6 +54,11 @@ export const ProfileUserFragment = gql`
       url
       displayName
       type
+    }
+    userInfo {
+      discordUsername
+      discordDiscriminator
+      twitterUsername
     }
     additionalInfo {
       orgCount


### PR DESCRIPTION
## :pushpin: References

- **Wonder issue:** https://app.wonderverse.xyz/dashboard?task=71275647331206066&view=grid
- **Related pull-requests:**

## :blue_book: Description
Add display for discord user. Also remove Discord and Twitter link on settings (personal profile) and have them connect instead
## :movie_camera: Screenshot or Video
<img width="1399" alt="Screenshot 2022-10-30 at 18 31 52" src="https://user-images.githubusercontent.com/6445805/198913735-2866ae69-0941-445c-82d6-9f4bfceb6a0b.png">

## :cake: Checklist:

- [x] I self-reviewed my changes
- [x] My changes follow the style guide: https://creative-earth-33e.notion.site/TT-Wonder-Style-guide-4702a45133374148953bfcaf584120b7
- [x] I tested my changes in Chrome
