### PR TITLE
fix: easy-assign username width

### DIFF
--- a/wondrous-app/components/Common/TaskViewModalUserChip/index.tsx
+++ b/wondrous-app/components/Common/TaskViewModalUserChip/index.tsx
@@ -34,7 +34,7 @@ const TaskViewModalUserChip = ({ user, handleRemove, onClick, canEdit = false })
         item
         container
         gap="6px"
-        width="40%"
+        maxWidth="85%"
         onClick={onClick}
         sx={{
           cursor: 'pointer',
@@ -43,12 +43,24 @@ const TaskViewModalUserChip = ({ user, handleRemove, onClick, canEdit = false })
         <Box width="24px" height="24px">
           {image}
         </Box>
-        <Box color={palette.white} fontWeight="500" fontSize="13px">
+        <Box
+          color={palette.white}
+          fontWeight="500"
+          fontSize="13px"
+          maxWidth="85%"
+          width="fit-content"
+          textOverflow="ellipsis"
+          sx={{
+            cursor: 'pointer',
+            whiteSpace: 'nowrap',
+            overflow: 'hidden',
+          }}
+        >
           {username}
         </Box>
       </Grid>
       {canEdit && (
-        <Grid container item justifyContent="flex-end" width="40%">
+        <Grid container item justifyContent="flex-end" width="24px">
           <Grid
             item
             container


### PR DESCRIPTION
## :pushpin: References

- **Wonder issue:** https://app.wonderverse.xyz/organization/wonderverse/boards?task=71564559914106890&entity=task
- **Related pull-requests:** https://github.com/wondrous-dev/wondrous-frontend/pull/1135

## :blue_book: Description

Fixes the username layout issue

## :movie_camera: Screenshot or Video

<img width="250" alt="image" src="https://user-images.githubusercontent.com/8164667/199178706-2a2d0fc9-7385-4e4a-81f7-e6b70d5574a1.png">


## :cake: Checklist:

- [x] I self-reviewed my changes
- [x] My changes follow the style guide: https://creative-earth-33e.notion.site/TT-Wonder-Style-guide-4702a45133374148953bfcaf584120b7
- [x] I tested my changes in Chrome
