### PR TITLE
feat: add snackbar to remind people to add Discord

### DIFF
--- a/wondrous-app/components/Header/index.tsx
+++ b/wondrous-app/components/Header/index.tsx
@@ -7,7 +7,7 @@ import { useContext, useEffect } from 'react';
 import { SnackbarAlertContext } from 'components/Common/SnackbarAlert';
 import { ConnectDiscordLink } from './styles';
 
-const DISCORD_SNACKBAR_DURATION = 1000 * 60 * 10;
+const DISCORD_SNACKBAR_DURATION = 1000 * 60 * 2;
 
 const HeaderComponent = () => {
   const user = useMe();
@@ -30,8 +30,15 @@ const HeaderComponent = () => {
   ];
   const showCreateButton = urlsWithCreateButton.some((url) => router.pathname?.includes(url));
 
+  const urlsWithDiscord = ['/mission-control', '/dashboard'];
   useEffect(() => {
-    if (user && !user?.userInfo?.discordUsername && router.pathname !== '/profile/settings') {
+    const randomNum = Math.random();
+    // either we land on dashboard or mission control, or there's 10% chance of showing the snackbar
+    if (
+      user &&
+      !user?.userInfo?.discordUsername &&
+      (urlsWithDiscord.indexOf(router.pathname) > -1 || (randomNum < 0.1 && router.pathname !== '/profile/settings'))
+    ) {
       setSnackbarAlertOpen(true);
       setSnackbarAlertAutoHideDuration(DISCORD_SNACKBAR_DURATION);
       setSnackbarAlertMessage(

--- a/wondrous-app/components/Header/index.tsx
+++ b/wondrous-app/components/Header/index.tsx
@@ -1,15 +1,19 @@
 import { useRouter } from 'next/router';
-import { useMutation } from '@apollo/client';
 
-import { MARK_ALL_NOTIFICATIONS_READ, MARK_NOTIFICATIONS_READ } from 'graphql/mutations/notification';
 import { useIsMobile, useGlobalContext } from 'utils/hooks';
-import { useMe, withAuth } from '../Auth/withAuth';
-import HeaderMemo from './HeaderMemo';
+import { useMe, withAuth } from 'components/Auth/withAuth';
+import HeaderMemo from 'components/Header/HeaderMemo';
+import { useContext, useEffect } from 'react';
+import { SnackbarAlertContext } from 'components/Common/SnackbarAlert';
+import { ConnectDiscordLink } from './styles';
+
+const DISCORD_SNACKBAR_DURATION = 1000 * 60 * 10;
 
 const HeaderComponent = () => {
   const user = useMe();
   const isMobile = useIsMobile();
-
+  const { setSnackbarAlertOpen, setSnackbarAlertMessage, setSnackbarAlertAutoHideDuration } =
+    useContext(SnackbarAlertContext);
   const globalContext = useGlobalContext();
   const { toggleCreateFormModal: openCreateFormModal } = globalContext;
   const router = useRouter();
@@ -25,6 +29,21 @@ const HeaderComponent = () => {
     '/mission-control',
   ];
   const showCreateButton = urlsWithCreateButton.some((url) => router.pathname?.includes(url));
+
+  useEffect(() => {
+    if (user && !user?.userInfo?.discordUsername && router.pathname !== '/profile/settings') {
+      setSnackbarAlertOpen(true);
+      setSnackbarAlertAutoHideDuration(DISCORD_SNACKBAR_DURATION);
+      setSnackbarAlertMessage(
+        <>
+          <ConnectDiscordLink href="/profile/settings" target="_blank" rel="noreferrer">
+            Connect your Discord
+          </ConnectDiscordLink>{' '}
+          <span>for notifications for upcoming tasks, comments and more!</span>
+        </>
+      );
+    }
+  }, [user]);
 
   return (
     <HeaderMemo

--- a/wondrous-app/components/Header/styles.tsx
+++ b/wondrous-app/components/Header/styles.tsx
@@ -235,3 +235,8 @@ export const MissionControlIconWrapper = styled(HeaderHomeButton)`
     }
   }
 `;
+
+export const ConnectDiscordLink = styled.a`
+  cursor: pointer;
+  color: ${palette.white};
+`;


### PR DESCRIPTION
## :pushpin: References

- **Wonder issue:** https://app.wonderverse.xyz/dashboard?task=72013176064966785&view=grid
- **Related pull-requests:**

## :blue_book: Description
Adds snackbar encouraging user to connect Discord if they haven't for notifications. In the future we'll ask for email add too when email notifications are in
## :movie_camera: Screenshot or Video
https://www.loom.com/share/86ebade24602468bb0053cbbf236ed34?focus_title=1&muted=1&from_recorder=1
## :cake: Checklist:

-  [x] I self-reviewed my changes
- [x] My changes follow the style guide: https://creative-earth-33e.notion.site/TT-Wonder-Style-guide-4702a45133374148953bfcaf584120b7
- [x] I tested my changes in Chrome
