### PR TITLE
fix: pod name on page display mis aligned

### DIFF
--- a/wondrous-app/components/organization/wrapper/styles.tsx
+++ b/wondrous-app/components/organization/wrapper/styles.tsx
@@ -95,7 +95,6 @@ export const HeaderTitleIcon = styled.div`
   display: flex;
   align-items: center;
   width: 100%;
-  margin-bottom: 8px;
   & > * {
     margin-left: 10px;
     :first-child {
@@ -112,7 +111,7 @@ export const HeaderTitle = styled(Typography)`
     display: flex;
     align-items: center;
     color: #ffffff;
-    margin-left: 20px;
+    margin-left: 4px;
     text-shadow: 0px 4px 4px rgba(0, 0, 0, 0.25);
   }
 `;
@@ -125,7 +124,7 @@ export const HeaderTag = styled(Typography)`
     font-weight: 400;
     font-size: 18px;
     line-height: 18px;
-    margin-left: 20px;
+    margin-left: 12px;
   }
 `;
 


### PR DESCRIPTION
## :pushpin: References

- **Wonder issue:** https://app.wonderverse.xyz/organization/wonderverse/boards?task=73100368825811544&entity=task

## :blue_book: Description

![image](https://user-images.githubusercontent.com/8164667/202327164-a3c4753a-7dc9-4f47-b74f-047f727cd303.png)

## :movie_camera: Screenshot or Video

<img width="226" alt="image" src="https://user-images.githubusercontent.com/8164667/202327322-86848bed-e272-4383-a0ab-c644a1f23774.png">


## :cake: Checklist:

- [ ] I self-reviewed my changes
- [ ] My changes follow the style guide: https://creative-earth-33e.notion.site/TT-Wonder-Style-guide-4702a45133374148953bfcaf584120b7
- [ ] I tested my changes in Chrome
