### PR TITLE
fix: close icon alignment

### DIFF
--- a/wondrous-app/components/Common/TaskViewModalUserChip/index.tsx
+++ b/wondrous-app/components/Common/TaskViewModalUserChip/index.tsx
@@ -64,6 +64,7 @@ const TaskViewModalUserChip = ({ user, handleRemove, onClick, canEdit = false })
           <Grid
             item
             container
+            alignItems="center"
             justifyContent="flex-end"
             onClick={handleRemove}
             width="24px"


### PR DESCRIPTION
## :pushpin: References

- **Wonder issue:** https://app.wonderverse.xyz/organization/wonderverse/boards?task=73777640450818884&entity=task

## :blue_book: Description

Fix the alignment of task reviewer / assignee

## :movie_camera: Screenshot or Video

<img width="265" alt="image" src="https://user-images.githubusercontent.com/8164667/203883431-07590151-a51c-4663-8a3d-012787109b73.png">

before:
<img width="271" alt="image" src="https://user-images.githubusercontent.com/8164667/203883558-cfa968b0-e958-4466-a0e5-972ade0a36b6.png">


## :cake: Checklist:

- [x] I self-reviewed my changes
- [x] My changes follow the style guide: https://creative-earth-33e.notion.site/TT-Wonder-Style-guide-4702a45133374148953bfcaf584120b7
- [x] I tested my changes in Chrome
