### PR TITLE
fix: remove undo on paid submissions

### DIFF
--- a/wondrous-app/components/Common/TaskSubmission/submissionItem.tsx
+++ b/wondrous-app/components/Common/TaskSubmission/submissionItem.tsx
@@ -23,6 +23,7 @@ import {
   SUBMISSION_COMMENT_TYPE,
   SUBMISSION_STATUS,
   TASK_STATUS_DONE,
+  TASK_STATUS_PAID,
   TASK_TYPE,
 } from 'utils/constants';
 import { transformTaskToTaskCard } from 'utils/helpers';
@@ -360,8 +361,8 @@ function ResubmitTaskSubmissionButton({
 }
 
 function ReopenTaskSubmission({ submission, setCommentType, onClick }) {
-  const { approvedAt, rejectedAt } = submission;
-  if (!(approvedAt || rejectedAt)) return null;
+  const { approvedAt, rejectedAt, paymentStatus } = submission;
+  if (!(approvedAt || rejectedAt) || paymentStatus === TASK_STATUS_PAID) return null;
   const text = approvedAt ? 'Undo approval' : 'Undo rejection';
   const handleOnClick = () => {
     setCommentType(null);


### PR DESCRIPTION
## :pushpin: References

- **Wonder issue:** https://app.wonderverse.xyz/organization/wonderverse/boards?task=71735849798074425&entity=task

## :blue_book: Description

Remove undo approval submission when it's paid

## :movie_camera: Screenshot or Video

## :cake: Checklist:

- [x] I self-reviewed my changes
- [x] My changes follow the style guide: https://creative-earth-33e.notion.site/TT-Wonder-Style-guide-4702a45133374148953bfcaf584120b7
- [x] I tested my changes in Chrome
