### PR TITLE
fix: compensation icon layout

### DIFF
--- a/wondrous-app/components/Common/Compensation/index.tsx
+++ b/wondrous-app/components/Common/Compensation/index.tsx
@@ -10,21 +10,27 @@ export default function Compensation({ rewards = null, ...props }) {
   const { icon, rewardAmount, symbol } = rewards[0] || {};
   const shrinkAmount = shrinkNumber(rewardAmount);
   return (
-    <Grid container width="fit-content" key={id} style={style}>
+    <Grid
+      container
+      width="fit-content"
+      key={id}
+      style={style}
+      height="28px"
+      minWidth="45px"
+      lineHeight="0"
+      borderRadius="25px"
+      padding="0"
+    >
       <Grid
         container
+        item
+        borderRadius="inherit"
         bgcolor={palette.grey99}
-        borderRadius="25px"
         gap="4px"
         alignItems="center"
         paddingRight="8px"
-        paddingLeft={icon ? '1px' : '8px'}
-        height="28px"
-        minWidth="45px"
-        justifyContent="space-between"
-        lineHeight="0"
+        paddingLeft={icon ? '2px' : '8px'}
         style={pillStyle}
-        width="fit-content"
       >
         {icon && (
           <Grid container item height="100%" width="max-content" alignItems="center">

--- a/wondrous-app/components/ListView/Item.tsx
+++ b/wondrous-app/components/ListView/Item.tsx
@@ -344,7 +344,7 @@ function ListViewItem({ task, entityType, isDragDisabled }) {
           </ListViewItemDataContainer>
           <ListViewItemActions>
             {dueDate && <DueDateText>{format(new Date(dueDate), 'MMM d')}</DueDateText>}
-            {rewards && rewards?.length > 0 && <Compensation pillStyle={{ padding: '10px' }} rewards={rewards} />}
+            {rewards && rewards?.length > 0 && <Compensation rewards={rewards} />}
             {displayPayButton && (
               <ButtonPrimary
                 onClick={(e) => {


### PR DESCRIPTION
## :pushpin: References

- **Wonder issue:** https://app.wonderverse.xyz/organization/wonderverse/boards?task=74872609376829643&entity=task

## :blue_book: Description

styling off in tasks ive created section

## :movie_camera: Screenshot or Video

![image](https://user-images.githubusercontent.com/8164667/206940447-6a192d70-c72e-42e1-9c2d-2c9302fd8e99.png)


## :cake: Checklist:

- [x] I self-reviewed my changes
- [x] My changes follow the style guide: https://creative-earth-33e.notion.site/TT-Wonder-Style-guide-4702a45133374148953bfcaf584120b7
- [x] I tested my changes in Chrome
