### PR TITLE
fix: close user filter

### DIFF
--- a/wondrous-app/components/Common/BoardFilters/userFilter.tsx
+++ b/wondrous-app/components/Common/BoardFilters/userFilter.tsx
@@ -1,4 +1,5 @@
 import { useOrgBoard, usePodBoard } from 'utils/hooks';
+import { useRouter } from 'next/router';
 import { SafeImage } from 'components/Common/Image';
 import DefaultUserImage from 'components/Common/Image/DefaultUserImage';
 import { AppliedFiltersItem, CloseIcon } from './styles';
@@ -8,8 +9,9 @@ export default function UserFilterPill() {
   const podBoard = usePodBoard();
 
   const board = orgBoard || podBoard;
-
-  if (!board?.user) return null;
+  const router = useRouter();
+  const { userId } = router.query;
+  if (!board?.user || !userId) return null;
   const { username, profilePicture } = board?.user;
 
   const deleteUserFilter = () => board?.deleteUserIdFilter();


### PR DESCRIPTION
## :pushpin: References

- **Wonder issue:**
- **Related pull-requests:**

## :blue_book: Description
Removes the user filter when we click the close icon
## :movie_camera: Screenshot or Video

## :cake: Checklist:

- [ ] I self-reviewed my changes
- [ ] My changes follow the style guide: https://creative-earth-33e.notion.site/TT-Wonder-Style-guide-4702a45133374148953bfcaf584120b7
- [ ] I tested my changes in Chrome
