### PR TITLE
fix: MoreInfoModal shows pod tab on podBoard

### DIFF
--- a/wondrous-app/components/profile/modals/index.tsx
+++ b/wondrous-app/components/profile/modals/index.tsx
@@ -92,8 +92,6 @@ const UserItem = forwardRef((props: any, ref) => {
 function MoreInfoModal(props) {
   const { orgId, podId, showUsers, showPods, open, handleClose, name } = props;
   const { podBoard } = useBoards();
-  const [displayUsers, setDisplayUsers] = useState(showUsers);
-  const [displayPods, setDisplayPods] = useState(showPods);
   const [hasMoreUsers, setHasMoreUsers] = useState(false);
   const [podList, setPodList] = useState([]);
   const [searchedUserList, setSearchedUserList] = useState([]);
@@ -104,7 +102,9 @@ function MoreInfoModal(props) {
   const userListItemRef = useRef(null);
   const podsOverflowBoxRef = useRef(null);
   const podListItemRef = useRef(null);
-  const [activeTab, setActiveTab] = useState(MODAL_TABS_MAP.CONTRIBUTORS);
+  const [activeTab, setActiveTab] = useState(null);
+  const displayUsers = activeTab === MODAL_TABS_MAP.CONTRIBUTORS;
+  const displayPods = activeTab === MODAL_TABS_MAP.PODS;
   const [getOrgPods, { data: orgPodData }] = useLazyQuery(GET_ORG_PODS, {
     fetchPolicy: 'cache-and-network',
   });
@@ -224,11 +224,9 @@ function MoreInfoModal(props) {
 
   useEffect(() => {
     if (showUsers && !displayUsers && !displayPods) {
-      setDisplayUsers(true);
       setActiveTab(MODAL_TABS_MAP.CONTRIBUTORS);
     }
     if (showPods && !displayUsers && !displayPods) {
-      setDisplayPods(true);
       setActiveTab(MODAL_TABS_MAP.PODS);
     }
     if (orgId) {
@@ -299,8 +297,6 @@ function MoreInfoModal(props) {
       open={open}
       onClose={() => {
         handleClose();
-        setDisplayUsers(false);
-        setDisplayPods(false);
         setActiveTab(MODAL_TABS_MAP.CONTRIBUTORS);
       }}
     >
@@ -310,8 +306,6 @@ function MoreInfoModal(props) {
           <CloseIconContainer
             onClick={() => {
               handleClose();
-              setDisplayUsers(false);
-              setDisplayPods(false);
               setActiveTab(MODAL_TABS_MAP.CONTRIBUTORS);
             }}
           >
@@ -322,22 +316,19 @@ function MoreInfoModal(props) {
           <StyledTabs value={activeTab} variant="fullWidth">
             <TabText
               onClick={() => {
-                setDisplayPods(false);
-                setDisplayUsers(true);
                 setActiveTab(MODAL_TABS_MAP.CONTRIBUTORS);
               }}
             >
-              <StyledTab isActive={activeTab === MODAL_TABS_MAP.CONTRIBUTORS} label="Contributors" />
+              <StyledTab isActive={displayUsers} label="Contributors" />
             </TabText>
+            ;
             {!podBoard && (
               <TabText
                 onClick={() => {
-                  setDisplayPods(true);
-                  setDisplayUsers(false);
                   setActiveTab(MODAL_TABS_MAP.PODS);
                 }}
               >
-                <StyledTab isActive={activeTab === MODAL_TABS_MAP.PODS} label="Pods" />{' '}
+                <StyledTab isActive={displayPods} label="Pods" />{' '}
               </TabText>
             )}
           </StyledTabs>

--- a/wondrous-app/components/profile/modals/index.tsx
+++ b/wondrous-app/components/profile/modals/index.tsx
@@ -1,6 +1,6 @@
 import React, { forwardRef, useEffect, useMemo, useRef, useState } from 'react';
 import Modal from '@mui/material/Modal';
-import { CircularProgress } from '@mui/material';
+import CircularProgress from '@mui/material/CircularProgress';
 import { GET_ORG_PODS, GET_ORG_USERS } from 'graphql/queries/org';
 import { GET_POD_USERS } from 'graphql/queries/pod';
 import { useLazyQuery } from '@apollo/client';
@@ -10,6 +10,7 @@ import { TaskModalBaseCard } from 'components/Common/Task/styles';
 import { useRouter } from 'next/router';
 import { CommentTopFlexDiv } from 'components/Comment/styles';
 import { cutString } from 'utils/helpers';
+import { useBoards } from 'utils/hooks';
 import { RichTextViewer } from 'components/RichText';
 import CloseModalIcon from 'components/Icons/closeModal';
 import { MODAL_TABS_MAP } from 'utils/constants';
@@ -90,6 +91,7 @@ const UserItem = forwardRef((props: any, ref) => {
 
 function MoreInfoModal(props) {
   const { orgId, podId, showUsers, showPods, open, handleClose, name } = props;
+  const { podBoard } = useBoards();
   const [displayUsers, setDisplayUsers] = useState(showUsers);
   const [displayPods, setDisplayPods] = useState(showPods);
   const [hasMoreUsers, setHasMoreUsers] = useState(false);
@@ -327,15 +329,17 @@ function MoreInfoModal(props) {
             >
               <StyledTab isActive={activeTab === MODAL_TABS_MAP.CONTRIBUTORS} label="Contributors" />
             </TabText>
-            <TabText
-              onClick={() => {
-                setDisplayPods(true);
-                setDisplayUsers(false);
-                setActiveTab(MODAL_TABS_MAP.PODS);
-              }}
-            >
-              <StyledTab isActive={activeTab === MODAL_TABS_MAP.PODS} label="Pods" />{' '}
-            </TabText>
+            {!podBoard && (
+              <TabText
+                onClick={() => {
+                  setDisplayPods(true);
+                  setDisplayUsers(false);
+                  setActiveTab(MODAL_TABS_MAP.PODS);
+                }}
+              >
+                <StyledTab isActive={activeTab === MODAL_TABS_MAP.PODS} label="Pods" />{' '}
+              </TabText>
+            )}
           </StyledTabs>
         </Container>
         <SearchBox>


### PR DESCRIPTION
## :pushpin: References

- **Wonder issue:** https://app.wonderverse.xyz/organization/wonderverse/boards?task=69716583481606700&entity=task

## :blue_book: Description

MoreInfoModal shows pod tab on podBoard

## :movie_camera: Screenshot or Video

![image](https://user-images.githubusercontent.com/8164667/207731584-98c9f9ad-d6e2-489b-a871-14e78d5b312c.png)


## :cake: Checklist:

- [x] I self-reviewed my changes
- [x] My changes follow the style guide: https://creative-earth-33e.notion.site/TT-Wonder-Style-guide-4702a45133374148953bfcaf584120b7
- [x] I tested my changes in Chrome
