### PR TITLE
update wrapper styling

### DIFF
--- a/wondrous-app/components/Pod/wrapper/index.tsx
+++ b/wondrous-app/components/Pod/wrapper/index.tsx
@@ -4,7 +4,14 @@ import { useRouter } from 'next/router';
 import { useLazyQuery, useMutation } from '@apollo/client';
 import ArrowForwardIosIcon from '@mui/icons-material/ArrowForwardIos';
 import palette from 'theme/palette';
-import { ENTITIES_TYPES, GR15DEICategoryName, PERMISSIONS, PRIVACY_LEVEL, HEADER_ASPECT_RATIO } from 'utils/constants';
+import {
+  ENTITIES_TYPES,
+  GR15DEICategoryName,
+  PERMISSIONS,
+  PRIVACY_LEVEL,
+  HEADER_ASPECT_RATIO,
+  EMPTY_RICH_TEXT_STRING,
+} from 'utils/constants';
 import { parseUserPermissionContext, removeUrlStart, toggleHtmlOverflow } from 'utils/helpers';
 import { usePodBoard } from 'utils/hooks';
 import { AspectRatio } from 'react-aspect-ratio';
@@ -335,8 +342,8 @@ function Wrapper(props) {
                             <DAOEmptyIcon />
                           </TokenEmptyLogo>
                         }
-                        width={60}
-                        height={60}
+                        width={50}
+                        height={50}
                         useNextImage
                         alt="Pod logo"
                         style={{
@@ -347,8 +354,8 @@ function Wrapper(props) {
                         <>
                           <GR15DEIModal open={openGR15Modal} onClose={() => setOpenGR15Modal(false)} />
                           <GR15DEILogo
-                            width="42"
-                            height="42"
+                            width="30"
+                            height="30"
                             onClick={(e) => {
                               e.preventDefault();
                               e.stopPropagation();
@@ -356,7 +363,7 @@ function Wrapper(props) {
                             }}
                             style={{
                               top: '0',
-                              right: '-20px',
+                              right: '-10px',
                               position: 'absolute',
                               zIndex: '20',
                             }}
@@ -373,8 +380,8 @@ function Wrapper(props) {
                     <PodIcon
                       color={podProfile?.color}
                       style={{
-                        width: 60,
-                        height: 60,
+                        width: 50,
+                        height: 50,
                         borderRadius: 50,
                       }}
                     />
@@ -427,9 +434,13 @@ function Wrapper(props) {
                   )}
                 </HeaderButtons>
               </HeaderMainBlock>
-              <HeaderText as="div">
-                <RichTextViewer text={podProfile?.description} />
-              </HeaderText>
+              {podProfile?.description && podProfile?.description !== EMPTY_RICH_TEXT_STRING ? (
+                <HeaderText as="div">
+                  <RichTextViewer text={podProfile?.description} />
+                </HeaderText>
+              ) : (
+                <div style={{ height: 10 }} />
+              )}
               <div>
                 <HeaderActivity>
                   {links?.map((link) => (

--- a/wondrous-app/components/organization/wrapper/styles.tsx
+++ b/wondrous-app/components/organization/wrapper/styles.tsx
@@ -106,11 +106,10 @@ export const HeaderTitle = styled(Typography)`
   && {
     font-weight: 500;
     font-size: 26px;
-    line-height: 36px;
     display: flex;
     align-items: center;
     color: #ffffff;
-    margin-left: 4px;
+    margin-left: 10px;
     text-shadow: 0px 4px 4px rgba(0, 0, 0, 0.25);
   }
 `;

--- a/wondrous-app/components/organization/wrapper/wrapper.tsx
+++ b/wondrous-app/components/organization/wrapper/wrapper.tsx
@@ -12,6 +12,7 @@ import {
   GR15DEICategoryName,
   BOUNTY_TYPE,
   HEADER_ASPECT_RATIO,
+  EMPTY_RICH_TEXT_STRING,
 } from 'utils/constants';
 import TaskViewModalWatcher from 'components/Common/TaskViewModal/TaskViewModalWatcher';
 import apollo from 'services/apollo';
@@ -387,8 +388,8 @@ function Wrapper(props) {
                           <DAOEmptyIcon />
                         </TokenEmptyLogo>
                       }
-                      width={60}
-                      height={60}
+                      width={50}
+                      height={50}
                       useNextImage
                       style={{
                         borderRadius: '6px',
@@ -399,12 +400,12 @@ function Wrapper(props) {
                       <>
                         <GR15DEIModal open={openGR15Modal} onClose={() => setOpenGR15Modal(false)} />
                         <GR15DEILogo
-                          width="42"
-                          height="42"
+                          width="30"
+                          height="30"
                           onClick={() => setOpenGR15Modal(true)}
                           style={{
                             top: '0',
-                            right: '-20px',
+                            right: '1px',
                             position: 'absolute',
                             zIndex: '25',
                           }}
@@ -475,9 +476,13 @@ function Wrapper(props) {
                 )}
               </HeaderButtons>
             </HeaderMainBlock>
-            <HeaderText as="div">
-              <RichTextViewer text={orgProfile?.description} />
-            </HeaderText>
+            {orgProfile?.description && orgProfile?.description !== EMPTY_RICH_TEXT_STRING ? (
+              <HeaderText as="div">
+                <RichTextViewer text={orgProfile?.description} />
+              </HeaderText>
+            ) : (
+              <div style={{ height: 10 }} />
+            )}
             <div>
               <HeaderActivity>
                 <HeaderContributors

--- a/wondrous-app/utils/constants.tsx
+++ b/wondrous-app/utils/constants.tsx
@@ -874,3 +874,5 @@ export const GRANT_APPLY_POLICY = {
 };
 
 export const PAGES_WITH_NO_ENTITY_SIDEBAR = ['/explore'];
+
+export const EMPTY_RICH_TEXT_STRING = '[{"children":[{"text":""}],"type":"paragraph"}]';


### PR DESCRIPTION
Styling enhancement of org/pod wrapper. reduce size of profile pic, add spacing. 
and not show description if description is not there

## :pushpin: References

- **Wonder issue:**
- **Related pull-requests:**

## :blue_book: Description

## :movie_camera: Screenshot or Video

## :cake: Checklist:

- [ ] I self-reviewed my changes
- [ ] My changes follow the style guide: https://creative-earth-33e.notion.site/TT-Wonder-Style-guide-4702a45133374148953bfcaf584120b7
- [ ] I tested my changes in Chrome
