### PR TITLE
fix: add onboarding to modal

### DIFF
--- a/wondrous-app/pages/_app.tsx
+++ b/wondrous-app/pages/_app.tsx
@@ -46,7 +46,11 @@ function renderSnippet() {
 }
 
 const Layout = ({ Component, pageProps }) =>
-  Component.getLayout ? Component.getLayout(<Component {...pageProps} />) : <Component {...pageProps} />;
+  Component.getLayout ? (
+    Component.getLayout(<Component id="tour-header-launch" {...pageProps} />)
+  ) : (
+    <Component id="tour-header-launch" {...pageProps} />
+  );
 
 function MyApp({ Component, pageProps }) {
   // Only uncomment this method if you have blocking data requirements for

--- a/wondrous-app/pages/_document.tsx
+++ b/wondrous-app/pages/_document.tsx
@@ -46,7 +46,7 @@ class MyDocument extends Document {
             rel="stylesheet"
           />
         </Head>
-        <body id="tour-header-launch">
+        <body>
           <script>0</script>
           <Main />
           <NextScript />


### PR DESCRIPTION
## :pushpin: References

- **Wonder issue:**
- **Related pull-requests:**

## :blue_book: Description
Makes it so the final training is within a modal
## :movie_camera: Screenshot or Video

## :cake: Checklist:

- [ ] I self-reviewed my changes
- [ ] My changes follow the style guide: https://creative-earth-33e.notion.site/TT-Wonder-Style-guide-4702a45133374148953bfcaf584120b7
- [ ] I tested my changes in Chrome
