### PR TITLE
fix: show pods when you click show pods on project home

### DIFF
--- a/wondrous-app/components/organization/wrapper/wrapper.tsx
+++ b/wondrous-app/components/organization/wrapper/wrapper.tsx
@@ -438,7 +438,8 @@ function Wrapper(props) {
                 <HeaderContributors
                   onClick={() => {
                     setMoreInfoModalOpen(true);
-                    setShowUsers(true);
+                    setShowUsers(false);
+                    setShowPods(true);
                   }}
                 >
                   <MemberPodIconBackground>


### PR DESCRIPTION
## :pushpin: References

- **Wonder issue:**
- **Related pull-requests:**

## :blue_book: Description
Opens pod list instead of user list when you click on pods button in project home
## :movie_camera: Screenshot or Video

## :cake: Checklist:

- [ ] I self-reviewed my changes
- [ ] My changes follow the style guide: https://creative-earth-33e.notion.site/TT-Wonder-Style-guide-4702a45133374148953bfcaf584120b7
- [ ] I tested my changes in Chrome
