### PR TITLE
Fix proposal layout and submission height

### DIFF
--- a/wondrous-app/components/Common/TaskSubmission/styles.tsx
+++ b/wondrous-app/components/Common/TaskSubmission/styles.tsx
@@ -386,7 +386,7 @@ export const SubmissionFormDescription = styled.div``;
 
 export const SubmissionDescriptionEditor = styled.div`
   padding: 12px;
-  height: 100px;
+  height: 150px;
   border-radius: 0 0 6px 6px;
   background: #1b1b1b;
   overflow: auto;

--- a/wondrous-app/components/CreateEntity/CreateEntityModal/Helpers/utils/index.tsx
+++ b/wondrous-app/components/CreateEntity/CreateEntityModal/Helpers/utils/index.tsx
@@ -351,15 +351,7 @@ export const entityTypeData = {
     },
   },
   [ENTITIES_TYPES.PROPOSAL]: {
-    fields: [
-      Fields.dueDate,
-      Fields.reward,
-      Fields.milestone,
-      Fields.priority,
-      Fields.tags,
-      Fields.voteOptions,
-      Fields.voteType,
-    ],
+    fields: [Fields.dueDate, Fields.reward, Fields.voteOptions, Fields.voteType],
     createMutation: useCreateTaskProposal,
     updateMutation: useUpdateTaskProposal,
     initialValues: {


### PR DESCRIPTION

## :pushpin: References

- **Wonder issue:**
- **Related pull-requests:**

## :blue_book: Description
Removes fields that don't work in proposal and increase height for task submissions
## :movie_camera: Screenshot or Video
<img width="577" alt="Screenshot 2023-02-04 at 04 38 54" src="https://user-images.githubusercontent.com/6445805/216707032-d53c0acf-b2af-44d3-b7e3-98321d27ef03.png">
## :cake: Checklist:

- [ ] I self-reviewed my changes
- [ ] My changes follow the style guide: https://creative-earth-33e.notion.site/TT-Wonder-Style-guide-4702a45133374148953bfcaf584120b7
- [ ] I tested my changes in Chrome
