### PR TITLE
fix title when empty entity

### DIFF
--- a/wondrous-app/components/Pod/boards/index.tsx
+++ b/wondrous-app/components/Pod/boards/index.tsx
@@ -57,7 +57,13 @@ function PodBoards(props: Props) {
   const entityTypeFilters = filters[entityType]?.filters || FILTER_STATUSES;
   const filterSchema: any = entityTypeFilters;
   return (
-    <BoardPageHeader onSearch={onSearch} filterSchema={filterSchema} onFilterChange={onFilterChange} userId={userId}>
+    <BoardPageHeader
+      headerTitle="Tasks"
+      onSearch={onSearch}
+      filterSchema={filterSchema}
+      onFilterChange={onFilterChange}
+      userId={userId}
+    >
       <ColumnsContext.Provider value={{ columns, setColumns }}>
         {loading ? (
           <BoardColumnsSkeleton />

--- a/wondrous-app/components/organization/boards/boards.tsx
+++ b/wondrous-app/components/organization/boards/boards.tsx
@@ -65,6 +65,7 @@ function OrgBoards(props: Props) {
       podIds={podIds}
       userId={userId}
       loading={loading}
+      headerTitle="Tasks"
     >
       <ColumnsContext.Provider value={{ columns, setColumns }}>
         {loading ? (


### PR DESCRIPTION
## :pushpin: References

- **Wonder issue:**
- **Related pull-requests:**

## :blue_book: Description

BoardPageHeader takes the title from the entity in the router query, if none is provided this means we're on the default entity ( Tasks ) 

## :movie_camera: Screenshot or Video

## :cake: Checklist:

- [ ] I self-reviewed my changes
- [ ] My changes follow the style guide: https://creative-earth-33e.notion.site/TT-Wonder-Style-guide-4702a45133374148953bfcaf584120b7
- [ ] I tested my changes in Chrome
