### PR TITLE
feat: add localization

### DIFF
--- a/wondrous-app/pages/_app.tsx
+++ b/wondrous-app/pages/_app.tsx
@@ -34,9 +34,11 @@ import { CornerWidgetProvider } from 'components/Common/CornerWidget';
 declare global {
   interface Window {
     analytics: any;
+    Localize: any;
   }
 }
 
+const LOCALIZE_KEY = process.env.NEXT_PUBLIC_LOCALIZE_KEY;
 function renderSnippet() {
   const opts = {
     apiKey: process.env.NEXT_PUBLIC_SEGMENT_WRITE_KEY || '',
@@ -106,6 +108,46 @@ function MyApp({ Component, pageProps }) {
         <link rel="shortcut icon" href="/images/favicon.ico" />
       </Head>
       <Script id="segment-script" dangerouslySetInnerHTML={{ __html: renderSnippet() }} />
+      <Script
+        id="localize"
+        src="https://global.localizecdn.com/localize.js"
+        onLoad={(a) => {
+          // eslint-disable-next-line no-unused-vars
+          !(function (a) {
+            if (!a.Localize) {
+              a.Localize = {};
+              for (
+                let e = [
+                    'translate',
+                    'untranslate',
+                    'phrase',
+                    'initialize',
+                    'translatePage',
+                    'setLanguage',
+                    'getLanguage',
+                    'getSourceLanguage',
+                    'detectLanguage',
+                    'getAvailableLanguages',
+                    'untranslatePage',
+                    'bootstrap',
+                    'prefetch',
+                    'on',
+                    'off',
+                    'hideWidget',
+                    'showWidget',
+                  ],
+                  t = 0;
+                t < e.length;
+                t++
+              )
+                a.Localize[e[t]] = function () {};
+              return true;
+            }
+          })(window);
+          // @ts-ignore
+          Localize.initialize({ key: LOCALIZE_KEY, rememberLanguage: true, autoApprove: true });
+        }}
+      />
       <IsMobileContext.Provider value={isMobile}>
         <StyledComponentProvider theme={theme}>
           <ThemeProvider theme={theme}>


### PR DESCRIPTION
## :pushpin: References

- **Wonder issue:**https://app.wonderverse.xyz/dashboard?task=80708261411553813
- **Related pull-requests:**

## :blue_book: Description
Add localization for Japanese, Spanish, Portugues, Korean and Simplified Chinese. We'll need to improve certain phrases via the Localize application.
<img width="1511" alt="Screenshot 2023-02-13 at 16 21 14" src="https://user-images.githubusercontent.com/6445805/218616143-fe169b2a-7657-4a85-9b4e-e57f79f48bd4.png">

## :movie_camera: Screenshot or Video

## :cake: Checklist:

- [ ] I self-reviewed my changes
- [ ] My changes follow the style guide: https://creative-earth-33e.notion.site/TT-Wonder-Style-guide-4702a45133374148953bfcaf584120b7
- [ ] I tested my changes in Chrome
