### PR TITLE
feat: add training wheels for project home on org and pod

### DIFF
--- a/wondrous-app/components/Button/index.tsx
+++ b/wondrous-app/components/Button/index.tsx
@@ -97,6 +97,7 @@ type Props = SpaceProps & {
    * We include several predefined button styles,
    * each serving its own semantic purpose, with a few extras thrown in for more control.
    */
+  id?: string;
   color?: 'primary' | 'secondary' | 'grey' | 'purple' | 'blue';
   children: ReactNode | undefined | string;
   minWidth?: number | string; // for values such as auto, fit-content, etc.

--- a/wondrous-app/components/Common/SidebarEntity/index.tsx
+++ b/wondrous-app/components/Common/SidebarEntity/index.tsx
@@ -71,6 +71,7 @@ const EntitySidebarButtons = () => {
               },
               ...sharedButtonTheme,
             }}
+            id="tour-header-project-settings"
           >
             Settings
           </Button>

--- a/wondrous-app/components/Guide/GuideNavigationWrapper.tsx
+++ b/wondrous-app/components/Guide/GuideNavigationWrapper.tsx
@@ -1,12 +1,21 @@
 import { useRouter } from 'next/router';
+import { useMe } from 'components/Auth/withAuth';
 import { NavigationWrapper } from './styles';
 import { guideConfig } from './guide';
 
+export const filterGuideSteps = ({ steps, user, router }) => {
+  const onProjectHome = router.pathname === '/organization/[username]/home' || router.pathname === '/pod/[podId]/home';
+  if (user?.lastCompletedGuide && onProjectHome) {
+    return steps.slice(1);
+  }
+  return steps;
+};
+
 function GuideNextButton({ nextButton, prevButton, currentStep, setIsOpen, setCurrentStep }) {
   const router = useRouter();
-
+  const user = useMe();
   const guide: any = guideConfig[router.pathname];
-  const steps = guide?.steps;
+  const steps = filterGuideSteps({ steps: guide?.steps, user, router });
 
   const NextBtn: any = nextButton;
   const PrevBtn: any = prevButton;

--- a/wondrous-app/components/Guide/GuideNextButton.tsx
+++ b/wondrous-app/components/Guide/GuideNextButton.tsx
@@ -1,16 +1,35 @@
 import { useRouter } from 'next/router';
+import { useMe } from 'components/Auth/withAuth';
 import { NextButton, LaunchButton, LaunchButtonText } from './styles';
 import { guideConfig } from './guide';
+import { filterGuideSteps } from './GuideNavigationWrapper';
 
-function GuideNextButton({ currentStep, stepsLength, setIsOpen, setCurrentStep, setUserCompletedGuide }) {
+function GuideNextButton({
+  currentStep,
+  stepsLength,
+  setIsOpen,
+  setCurrentStep,
+  setUserCompletedGuide,
+  setProjectCompletedGuide,
+}) {
   const router = useRouter();
-
+  const onProjectHome = router.pathname === '/organization/[username]/home' || router.pathname === '/pod/[podId]/home';
   const guide: any = guideConfig[router.pathname];
-  const steps = guide?.steps;
-
+  const user = useMe();
+  const steps = filterGuideSteps({ steps: guide?.steps, user, router });
   const stepsData = steps[currentStep];
   const buttonTitle = stepsData?.nextButtonTitle || 'Next';
-  const action = () => {
+  const action = async () => {
+    if (stepsData.nextAction === 'finish' && onProjectHome) {
+      console.log('hello');
+      if (guide?.id) {
+        await setProjectCompletedGuide({
+          variables: {
+            guideId: guide?.id,
+          },
+        });
+      }
+    }
     if (currentStep === steps.length - 1) {
       return setIsOpen(false);
     }
@@ -19,7 +38,7 @@ function GuideNextButton({ currentStep, stepsLength, setIsOpen, setCurrentStep, 
   if (stepsData?.nextAction === 'skip') {
     return null;
   }
-  if (stepsData.nextAction === 'finish') {
+  if (stepsData.nextAction === 'finish' && !onProjectHome) {
     return (
       <LaunchButton
         onClick={async () => {

--- a/wondrous-app/components/Guide/GuidePrevButton.tsx
+++ b/wondrous-app/components/Guide/GuidePrevButton.tsx
@@ -1,12 +1,15 @@
 import { useRouter } from 'next/router';
+import { useMe } from 'components/Auth/withAuth';
 import { PrevButton, LaunchButton, LaunchButtonText } from './styles';
 import { guideConfig } from './guide';
+import { filterGuideSteps } from './GuideNavigationWrapper';
 
 function GuidePrevButton({ currentStep, stepsLength, setIsOpen, setCurrentStep, setUserCompletedGuide }) {
   const router = useRouter();
-
+  const user = useMe();
+  const onProjectHome = router.pathname === '/organization/[username]/home' || router.pathname === '/pod/[podId]/home';
   const guide: any = guideConfig[router.pathname];
-  const steps = guide?.steps;
+  const steps = filterGuideSteps({ steps: guide?.steps, user, router });
 
   const stepsData = steps[currentStep];
   const buttonTitle = stepsData?.prevButtonTitle || 'Next';
@@ -16,7 +19,7 @@ function GuidePrevButton({ currentStep, stepsLength, setIsOpen, setCurrentStep, 
     }
     return setCurrentStep((step) => step - 1);
   };
-  if (stepsData.nextAction === 'finish') {
+  if (stepsData.nextAction === 'finish' && !onProjectHome) {
     return (
       <LaunchButton
         onClick={async () => {

--- a/wondrous-app/components/Guide/guide.tsx
+++ b/wondrous-app/components/Guide/guide.tsx
@@ -1,5 +1,167 @@
 import { StepTitle, StepBody } from './styles';
 
+const projectHomeSteps = [
+  {
+    selector: '#tour-header-create-btn',
+    position: 'bottom',
+    content: () => (
+      <div>
+        <StepTitle gradient="linear-gradient(180deg, #FFFFFF 0%, #06FFA5 100%)">Your creation button</StepTitle>
+        <StepBody>Create tasks, proposals, and milestones by clicking here.</StepBody>
+      </div>
+    ),
+    nextButtonTitle: 'Continue',
+    prevButtonTitle: 'Skip training',
+    prevAction: 'skip',
+  },
+  {
+    selector: '#tour-header-project-settings',
+    position: 'top',
+    content: () => (
+      <div>
+        <StepTitle gradient="linear-gradient(46.92deg, #B820FF 8.72%, #FFFFFF 115.55%)">Settings</StepTitle>
+        <StepBody>
+          Here you can configure payment methods, Gnosis wallets, integrations, task imports and more!{' '}
+        </StepBody>
+      </div>
+    ),
+    nextButtonTitle: 'Continue',
+    prevButtonTitle: 'Skip training',
+    prevAction: 'skip',
+  },
+  {
+    selector: '#tour-header-project-pods',
+    position: 'right',
+    content: () => (
+      <div>
+        <StepTitle gradient="linear-gradient(46.92deg, #B820FF 8.72%, #FFFFFF 115.55%)">Pods</StepTitle>
+        <StepBody>
+          Pods are the teams within your org. They can be made private or public and be subject to gating rules
+          configured in settings.
+        </StepBody>
+      </div>
+    ),
+    nextButtonTitle: 'Continue',
+    prevButtonTitle: 'Skip training',
+    prevAction: 'skip',
+  },
+  {
+    selector: '#tour-header-project-tasks',
+    position: 'left',
+    content: () => (
+      <div>
+        <StepTitle gradient="linear-gradient(46.92deg, #B820FF 8.72%, #FFFFFF 115.55%)">Tasks</StepTitle>
+        <StepBody>
+          Tasks are the central units of work led by a single contributor. You can assign them or create applications to
+          filter contributors. You can reward tasks with payment methods of your choice or with a flexible points
+          system. You can create subtasks within tasks.{' '}
+        </StepBody>
+      </div>
+    ),
+    nextButtonTitle: 'Continue',
+    prevButtonTitle: 'Skip training',
+    prevAction: 'skip',
+  },
+  {
+    selector: '#tour-header-project-bounties',
+    position: 'left',
+    content: () => (
+      <div>
+        <StepTitle gradient="linear-gradient(46.92deg, #B820FF 8.72%, #FFFFFF 115.55%)">Bounties</StepTitle>
+        <StepBody>
+          Bounties are flexible tasks that can have many submissions and have one off or variable payout amounts to
+          reward better submissions.{' '}
+        </StepBody>
+      </div>
+    ),
+    nextButtonTitle: 'Continue',
+    prevButtonTitle: 'Skip training',
+    prevAction: 'skip',
+  },
+  {
+    selector: '#tour-header-project-milestones',
+    position: 'left',
+    content: () => (
+      <div>
+        <StepTitle gradient="linear-gradient(46.92deg, #B820FF 8.72%, #FFFFFF 115.55%)">Milestones</StepTitle>
+        <StepBody>
+          Milestones are goals that you or your teams are tracking toward. It can be a metric, like gain 10k twitter
+          followers, or a mini-project (like a sprint) with a bunch of tasks within it.{' '}
+        </StepBody>
+      </div>
+    ),
+    nextButtonTitle: 'Continue',
+    prevButtonTitle: 'Skip training',
+    prevAction: 'skip',
+  },
+  {
+    selector: '#tour-header-project-proposals',
+    position: 'left',
+    content: () => (
+      <div>
+        <StepTitle gradient="linear-gradient(46.92deg, #B820FF 8.72%, #FFFFFF 115.55%)">Proposals</StepTitle>
+        <StepBody>
+          Proposals are a way for you to tap into your community for feedback, governance decisions, and much more.
+          Users can create proposals that can be approved or denied by admins. Proposals can be voted on through polls
+          or a Snapshot vote. Once accepted, proposals turn into tasks.{' '}
+        </StepBody>
+      </div>
+    ),
+    nextButtonTitle: 'Continue',
+    prevButtonTitle: 'Skip training',
+    prevAction: 'skip',
+  },
+  {
+    selector: '#tour-header-project-collabs',
+    position: 'left',
+    content: () => (
+      <div>
+        <StepTitle gradient="linear-gradient(46.92deg, #B820FF 8.72%, #FFFFFF 115.55%)">Collabs</StepTitle>
+        <StepBody>
+          Collabs are shared workspaces between you and your partners. You can share work between multiple orgs while
+          being able to see everything aggregated in your mission control{' '}
+        </StepBody>
+      </div>
+    ),
+    nextButtonTitle: 'Continue',
+    prevButtonTitle: 'Skip training',
+    prevAction: 'skip',
+  },
+  {
+    selector: '#tour-header-project-grants',
+    position: 'left',
+    content: () => (
+      <div>
+        <StepTitle gradient="linear-gradient(46.92deg, #B820FF 8.72%, #FFFFFF 115.55%)">Grants</StepTitle>
+        <StepBody>
+          You can create and manage grants given to your community to build projects for your org. You can gate who can
+          apply, generate application templates and pay out grants.{' '}
+        </StepBody>
+      </div>
+    ),
+    nextButtonTitle: 'Continue',
+    prevButtonTitle: 'Skip training',
+    prevAction: 'skip',
+  },
+  {
+    selector: '#tour-header-project-docs',
+    position: 'left',
+    content: () => (
+      <div>
+        <StepTitle gradient="linear-gradient(46.92deg, #B820FF 8.72%, #FFFFFF 115.55%)">Docs</StepTitle>
+        <StepBody>
+          You can link documents (Google docs, Notion, Figma, etc) so your community can get more context/resources
+          about you. These can be made to be members only or public.{' '}
+        </StepBody>
+      </div>
+    ),
+    nextButtonTitle: 'Finish',
+    prevButtonTitle: 'Skip training',
+    prevAction: 'skip',
+    nextAction: 'finish',
+  },
+];
+
 export const guideConfig = {
   '/mission-control': {
     id: 'mission_control_guide',
@@ -60,5 +222,15 @@ export const guideConfig = {
         nextAction: 'finish',
       },
     ],
+  },
+  '/organization/[username]/home': {
+    id: 'organization_home_guide',
+    steps: projectHomeSteps,
+  },
+  '/pod/[podId]/home': {
+    id: 'pod_home_guide',
+    steps: projectHomeSteps.filter(
+      (item) => item.selector !== '#tour-header-project-collabs' && item.selector !== '#tour-header-project-pods'
+    ),
   },
 };

--- a/wondrous-app/components/Guide/index.tsx
+++ b/wondrous-app/components/Guide/index.tsx
@@ -1,13 +1,14 @@
 import { TourProvider } from '@reactour/tour';
 import { useMutation } from '@apollo/client';
-import { SET_USER_COMPLETED_GUIDE } from 'graphql/mutations/user';
+import { SET_USER_COMPLETED_GUIDE, SET_PROJECT_COMPLETED_GUIDE } from 'graphql/mutations/user';
 import { useRouter } from 'next/router';
 import { toggleHtmlOverflow } from 'utils/helpers';
 import { GET_LOGGED_IN_USER } from 'graphql/queries';
 import GuideNextButton from 'components/Guide/GuideNextButton';
 import GuidePrevButton from 'components/Guide/GuidePrevButton';
-import GuideNavigationWrapper from 'components/Guide/GuideNavigationWrapper';
+import GuideNavigationWrapper, { filterGuideSteps } from 'components/Guide/GuideNavigationWrapper';
 import palette from 'theme/palette';
+import { useMe } from 'components/Auth/withAuth';
 import { guideConfig } from './guide';
 
 export default function OnboardingGuide({ children }) {
@@ -15,21 +16,34 @@ export default function OnboardingGuide({ children }) {
     refetchQueries: [{ query: GET_LOGGED_IN_USER }],
   });
 
-  const router = useRouter();
+  const [setProjectCompletedGuide] = useMutation(SET_PROJECT_COMPLETED_GUIDE, {
+    refetchQueries: [{ query: GET_LOGGED_IN_USER }],
+  });
 
+  const router = useRouter();
+  const user = useMe();
   const guide: any = guideConfig[router.pathname];
-  const steps = guide?.steps;
+  const onProjectHome = router.pathname === '/organization/[username]/home' || router.pathname === '/pod/[podId]/home';
+  const steps = filterGuideSteps({ steps: guide?.steps, user, router });
   const disableBody = () => {
     toggleHtmlOverflow();
   };
   const beforeClose = () => {
     toggleHtmlOverflow();
     if (guide?.id) {
-      setUserCompletedGuide({
-        variables: {
-          guideId: guide?.id,
-        },
-      });
+      if (onProjectHome) {
+        setProjectCompletedGuide({
+          variables: {
+            guideId: guide?.id,
+          },
+        });
+      } else {
+        setUserCompletedGuide({
+          variables: {
+            guideId: guide?.id,
+          },
+        });
+      }
     }
   };
 
@@ -49,6 +63,8 @@ export default function OnboardingGuide({ children }) {
   };
 
   if (!guide?.id) return <>{children}</>;
+
+  if (!user) return null;
   return (
     <TourProvider
       afterOpen={disableBody}
@@ -78,6 +94,7 @@ export default function OnboardingGuide({ children }) {
           setIsOpen={setIsOpen}
           setCurrentStep={setCurrentStep}
           setUserCompletedGuide={setUserCompletedGuide}
+          setProjectCompletedGuide={setProjectCompletedGuide}
         />
       )}
       prevButton={({ currentStep, stepsLength, setIsOpen, setCurrentStep }) => (

--- a/wondrous-app/components/Pod/project.tsx
+++ b/wondrous-app/components/Pod/project.tsx
@@ -1,4 +1,6 @@
 import { useQuery } from '@apollo/client';
+import { useTour } from '@reactour/tour';
+import { useMe } from 'components/Auth/withAuth';
 import EntitySidebar from 'components/Common/SidebarEntity';
 import GrantApplicationPodCreateModal from 'components/GrantApplications/GrantApplicationPodCreateModal';
 import HomePageHeader from 'components/Pod/wrapper/HomePageHeader';
@@ -12,6 +14,8 @@ import { usePageDataContext } from 'utils/hooks';
 const PodProject = () => {
   const { podId } = useRouter().query;
   const { setPageData } = usePageDataContext();
+  const { setIsOpen, setCurrentStep } = useTour();
+  const user = useMe();
   const { data } = useQuery(GET_POD_BY_ID, {
     skip: !podId,
     variables: {
@@ -25,6 +29,12 @@ const PodProject = () => {
     fetchPolicy: 'cache-and-network',
   });
   useEffect(() => () => setPageData({}), []);
+  useEffect(() => {
+    if (user && !user?.lastCompletedProjectGuide) {
+      setCurrentStep(0);
+      setIsOpen(true);
+    }
+  }, [user]);
   const { getPodById } = data || {};
 
   const contextValue = useMemo(

--- a/wondrous-app/components/ProjectProfile/HeaderTitle.tsx
+++ b/wondrous-app/components/ProjectProfile/HeaderTitle.tsx
@@ -19,8 +19,8 @@ const HeaderText = styled(Typography)`
   }
 `;
 
-const HeaderTitle = ({ text, IconComponent }: IHeaderTitleProps) => (
-  <Grid container width="fit-content" height="36px" gap="8px" alignItems="center" justifyContent="center">
+const HeaderTitle = ({ text, IconComponent, tourId }: IHeaderTitleProps) => (
+  <Grid id={tourId} container width="fit-content" height="36px" gap="8px" alignItems="center" justifyContent="center">
     <Tooltip title="Drag to move" placement="top">
       <DndIconWrapper
         container

--- a/wondrous-app/components/ProjectProfile/PodSection.tsx
+++ b/wondrous-app/components/ProjectProfile/PodSection.tsx
@@ -63,7 +63,7 @@ const PodCards = () => {
   return (
     <Grid container bgcolor={palette.grey900} padding="14px" gap="14px" borderRadius="6px">
       <Grid container justifyContent="space-between">
-        <HeaderTitle IconComponent={PodIcon} text="Pods" />
+        <HeaderTitle tourId="tour-header-project-pods" IconComponent={PodIcon} text="Pods" />
         <ShowAllButton />
       </Grid>
       <Grid container item width="100%" height="fit-content" gap="8px" flexWrap="nowrap">

--- a/wondrous-app/components/ProjectProfile/ProfileBountySection.tsx
+++ b/wondrous-app/components/ProjectProfile/ProfileBountySection.tsx
@@ -34,6 +34,7 @@ const ProfileBountySection = () => {
           router.push({ query: { ...router.query, task: id } }, undefined, { scroll: false }),
       }}
       data={homePageTaskObjects?.bounties}
+      tourId="tour-header-project-bounties"
     />
   );
 };

--- a/wondrous-app/components/ProjectProfile/ProfileCategorySection.tsx
+++ b/wondrous-app/components/ProjectProfile/ProfileCategorySection.tsx
@@ -38,6 +38,7 @@ const ProfileCategorySection = () => (
       onClick: ({ router, data: { id }, entityLink }) => router.push(`${entityLink}/docs?id=${id}`),
     }}
     data={useGetDocumentCategories()}
+    tourId="tour-header-project-docs"
   />
 );
 

--- a/wondrous-app/components/ProjectProfile/ProfileCollabSection.tsx
+++ b/wondrous-app/components/ProjectProfile/ProfileCollabSection.tsx
@@ -79,6 +79,7 @@ const ProfileCollabSection = () => (
       onClick: ({ router, data: { username } }) => router.push(`/collaboration/${username}/boards`),
     }}
     data={useGetOrgHomeCollabs()}
+    tourId="tour-header-project-collabs"
   />
 );
 

--- a/wondrous-app/components/ProjectProfile/ProfileGrantSection.tsx
+++ b/wondrous-app/components/ProjectProfile/ProfileGrantSection.tsx
@@ -85,6 +85,7 @@ const ProfileGrantSection = () => (
       onClick: ({ router, data: { id }, entityLink }) => router.push(`${entityLink}/grants?grant=${id}`),
     }}
     data={useGetGrantOrgBoard()}
+    tourId="tour-header-project-grants"
   />
 );
 

--- a/wondrous-app/components/ProjectProfile/ProfileMilestoneSection.tsx
+++ b/wondrous-app/components/ProjectProfile/ProfileMilestoneSection.tsx
@@ -43,6 +43,7 @@ const ProfileMilestoneSection = () => {
           router.push({ query: { ...router.query, task: id } }, undefined, { scroll: false }),
       }}
       data={homePageTaskObjects?.milestones}
+      tourId="tour-header-project-milestones"
     />
   );
 };

--- a/wondrous-app/components/ProjectProfile/ProfileProposalSection.tsx
+++ b/wondrous-app/components/ProjectProfile/ProfileProposalSection.tsx
@@ -44,6 +44,7 @@ const ProfileProposalSection = () => (
         router.push({ query: { ...router.query, taskProposal: id } }, undefined, { scroll: false }),
     }}
     data={useGetProposal()}
+    tourId="tour-header-project-proposals"
   />
 );
 

--- a/wondrous-app/components/ProjectProfile/ProfileTaskSection.tsx
+++ b/wondrous-app/components/ProjectProfile/ProfileTaskSection.tsx
@@ -45,6 +45,7 @@ const ProfileTaskSection = () => {
           router.push({ query: { ...router.query, task: id } }, undefined, { scroll: false }),
       }}
       data={homePageTaskObjects?.tasks}
+      tourId="tour-header-project-tasks"
     />
   );
 };

--- a/wondrous-app/components/ProjectProfile/SectionContent.tsx
+++ b/wondrous-app/components/ProjectProfile/SectionContent.tsx
@@ -18,6 +18,7 @@ const SectionContent = ({
   HeaderTitleProps,
   showAllUrl,
   data,
+  tourId,
   ListItemProps,
 }: ListWrapperProps) => {
   const { hasFullOrEditPermission } = useBoardPermission();
@@ -30,7 +31,7 @@ const SectionContent = ({
     <>
       <Grid container item flexDirection="column" flexGrow="1" padding="14px" gap="14px">
         <Grid container item alignItems="center" justifyContent="space-between">
-          <HeaderTitle {...HeaderTitleProps} />
+          <HeaderTitle tourId={tourId} {...HeaderTitleProps} />
           {hasFullOrEditPermission ? <AddButton {...CreateButtonProps} {...HeaderTitleProps} /> : null}
         </Grid>
         <Grid item container flexDirection="column" gap="10px" flexGrow="1">

--- a/wondrous-app/components/ProjectProfile/types.ts
+++ b/wondrous-app/components/ProjectProfile/types.ts
@@ -14,6 +14,7 @@ export interface IListItemProps {
 export interface IHeaderTitleProps {
   text: string;
   IconComponent: React.ElementType;
+  tourId?: string;
 }
 
 export interface ICreateButtonProps {
@@ -26,6 +27,7 @@ export interface ListWrapperProps {
   CreateButtonProps?: ICreateButtonProps;
   HeaderTitleProps: IHeaderTitleProps;
   showAllUrl: string;
+  tourId?: string;
   data?: Array<{
     [key: string]: any;
   }>;

--- a/wondrous-app/components/organization/project.tsx
+++ b/wondrous-app/components/organization/project.tsx
@@ -1,4 +1,6 @@
 import { useQuery } from '@apollo/client';
+import { useTour } from '@reactour/tour';
+import { useMe } from 'components/Auth/withAuth';
 import EntitySidebar from 'components/Common/SidebarEntity';
 import HomePageHeader from 'components/organization/wrapper/HomePageHeader';
 import ProjectProfile from 'components/ProjectProfile';
@@ -9,7 +11,10 @@ import { OrgBoardContext } from 'utils/contexts';
 import { usePageDataContext } from 'utils/hooks';
 
 const OrgProject = () => {
-  const { username } = useRouter().query;
+  const router = useRouter();
+  const { username } = router.query;
+  const user = useMe();
+  const { setIsOpen, setCurrentStep } = useTour();
   const { setPageData } = usePageDataContext();
   const { data: userPermissionsContext } = useQuery(GET_USER_PERMISSION_CONTEXT, {
     fetchPolicy: 'cache-and-network',
@@ -30,6 +35,12 @@ const OrgProject = () => {
 
   useEffect(() => () => setPageData({}), []);
 
+  useEffect(() => {
+    if (user && !user?.lastCompletedProjectGuide) {
+      setCurrentStep(0);
+      setIsOpen(true);
+    }
+  }, [user]);
   const contextValue = useMemo(
     () => ({
       userPermissionsContext: userPermissionsContext?.getUserPermissionContext

--- a/wondrous-app/graphql/fragments/user.ts
+++ b/wondrous-app/graphql/fragments/user.ts
@@ -19,6 +19,7 @@ export const LoggedinUserFragment = gql`
     }
     signupCompleted
     lastCompletedGuide
+    lastCompletedProjectGuide
     mainBannerClosedAt
     links {
       url

--- a/wondrous-app/graphql/mutations/user.ts
+++ b/wondrous-app/graphql/mutations/user.ts
@@ -94,6 +94,14 @@ export const SET_USER_COMPLETED_GUIDE = gql`
   }
 `;
 
+export const SET_PROJECT_COMPLETED_GUIDE = gql`
+  mutation setProjectHomeCompletedGuide($guideId: String!) {
+    setProjectHomeCompletedGuide(guideId: $guideId) {
+      success
+    }
+  }
+`;
+
 export const CREATE_USER_INTEREST = gql`
   mutation createUserInterests($interests: [String]) {
     createUserInterests(interests: $interests) {


### PR DESCRIPTION
## :pushpin: References

- **Wonder issue:** 
- **Related pull-requests:** https://github.com/wondrous-dev/wondrous-backend/pull/705

## :blue_book: Description
Add training wheels for those who visit project home for the first time. If they land on pod first, they'll go through pod flow and not get a repeat of org flow
## :movie_camera: Screenshot or Video
Org: https://www.loom.com/share/19da9d3fe2fa4c81b0be4a1dcc6db9c3
Pod: https://www.loom.com/share/a349e576d5ed4559b84cc3302e660a86

## :cake: Checklist:

- [ ] I self-reviewed my changes
- [ ] My changes follow the style guide: https://creative-earth-33e.notion.site/TT-Wonder-Style-guide-4702a45133374148953bfcaf584120b7
- [ ] I tested my changes in Chrome
