### PR TITLE
fix: CornerWidget and localizedjs overlaps

### DIFF
--- a/wondrous-app/components/Common/CornerWidget/CornerWidgetProvider.tsx
+++ b/wondrous-app/components/Common/CornerWidget/CornerWidgetProvider.tsx
@@ -22,6 +22,11 @@ const CornerWidgetProvider = ({ children }) => {
         open={open}
         onClose={handleClose}
         autoHideDuration={6000}
+        sx={{
+          '&.MuiSnackbar-root': {
+            bottom: '48px',
+          },
+        }}
       >
         <div>{open && <CornerWidget handleClose={handleClose} {...value} />}</div>
       </Snackbar>


### PR DESCRIPTION
## :pushpin: References

- **Wonder issue:** https://app.wonderverse.xyz/organization/wonderverse/boards?task=85783014471107376&entity=task
- **Related pull-requests:**

## :blue_book: Description

## :movie_camera: Screenshot or Video

### before

![image](https://user-images.githubusercontent.com/8164667/231619466-319c5ac8-6968-48b7-9fd3-2d7789acb112.png)

### after

<img width="379" alt="image" src="https://user-images.githubusercontent.com/8164667/231619442-fb0dcfdf-a7fe-4aed-937e-c887a19d6903.png">


## :cake: Checklist:

- [ ] I self-reviewed my changes
- [ ] My changes follow the style guide: https://creative-earth-33e.notion.site/TT-Wonder-Style-guide-4702a45133374148953bfcaf584120b7
- [ ] I tested my changes in Chrome
