### PR TITLE
fix options change

### DIFF
--- a/wondrous-bot-admin/src/components/AddFormEntity/index.tsx
+++ b/wondrous-bot-admin/src/components/AddFormEntity/index.tsx
@@ -18,17 +18,7 @@ import { useContext } from "react";
 import CreateQuestContext from "utils/context/CreateQuestContext";
 import { CONFIG_COMPONENTS } from "utils/configComponents";
 
-const MULTICHOICE_DEFAULT_VALUE = {
-  question: "",
-  withCorrectAnswers: false,
-  multiSelectValue: TYPES.MULTI_QUIZ,
-  answers: [
-    {
-      value: "",
-      isCorrect: true,
-    },
-  ],
-};
+
 
 const COMPONENT_OPTIONS = [
   {
@@ -109,6 +99,18 @@ const AddFormEntity = ({ steps, setSteps, handleRemove, refs }) => {
       };
     });
 
+    const MULTICHOICE_DEFAULT_VALUE = {
+      question: "",
+      withCorrectAnswers: false,
+      multiSelectValue: TYPES.MULTI_QUIZ,
+      answers: [
+        {
+          value: "",
+          isCorrect: true,
+        },
+      ],
+    };
+    
     const newConfiguration = steps.reduce((acc, next) => {
       if (next.id === id) {
         acc = [
@@ -156,6 +158,7 @@ const AddFormEntity = ({ steps, setSteps, handleRemove, refs }) => {
         },
       };
     });
+    
     const newConfiguration = steps.reduce((acc, next) => {
       if (next.id === id) {
         acc = [
@@ -188,7 +191,6 @@ const AddFormEntity = ({ steps, setSteps, handleRemove, refs }) => {
       acc.push(next);
       return acc;
     }, []);
-    // debugger
     setSteps(newConfiguration);
   };
 


### PR DESCRIPTION
## :pushpin: References

- **Wonder issue:**
- **Related pull-requests:**

## :blue_book: Description

Fixes a bug where the next multichoice first option was picking up the previous option

## :movie_camera: Screenshot or Video

## :cake: Checklist:

- [ ] I self-reviewed my changes
- [ ] My changes follow the style guide: https://creative-earth-33e.notion.site/TT-Wonder-Style-guide-4702a45133374148953bfcaf584120b7
- [ ] I tested my changes in Chrome
