### PR TITLE
feat: allow customization of quest notif

### DIFF
--- a/wondrous-bot-admin/src/components/ViewQuestResults/PublishQuestCardBody.tsx
+++ b/wondrous-bot-admin/src/components/ViewQuestResults/PublishQuestCardBody.tsx
@@ -9,27 +9,34 @@ import { PUSH_QUEST_DISCORD_NOTFICATION } from "graphql/mutations/discord";
 import { useMutation } from "@apollo/client";
 import useAlerts from "utils/hooks";
 import Switch from "components/Shared/Switch";
+import TextField from "components/Shared/TextField";
 
-const PublishQuestModal = ({ onClose, channelName, handlePublish, mentionChannel, setMentionChannel }) => {
+const PublishQuestModal = ({ onClose, channelName, handlePublish, message, setMessage }) => {
   return (
     <Grid display="flex" flexDirection="column" gap="10px" width="10)%">
       <Typography fontFamily="Poppins" fontWeight={600} fontSize="14px" color="#06040A">
         Are you sure you want to publish this quest to #{channelName} in Discord?
       </Typography>
-      <Box display="flex" gap="10px" alignItems="center" width="100%" marginTop="8px" marginBottom="8px">
-        <Switch
-          value={mentionChannel}
-          onChange={() => {
-            setMentionChannel(!mentionChannel);
-          }}
-        />
+      <Box display="flex" gap="10px" alignItems="center" width="100%">
         <Label
           style={{
             marginRight: "8px",
           }}
         >
-          Mention @here in channel
+          Channel Message (please edit as you like)
         </Label>
+      </Box>
+      <Box width="100%" marginBottom="8px">
+        <TextField
+          onChange={setMessage}
+          style={{
+            width: "100%",
+            fontFamily: "Poppins",
+          }}
+          value={message}
+          multiline={true}
+          error={null}
+        />
       </Box>
       <Box display="flex" gap="10px" alignItems="center" width="100%">
         <SharedSecondaryButton
@@ -57,6 +64,9 @@ const PublishQuestCardBody = ({ guildDiscordChannels, quest, orgId, existingNoti
   const [openPublishModal, setOpenPublishModal] = useState(false);
   const { setSnackbarAlertOpen, setSnackbarAlertMessage, setSnackbarAlertAnchorOrigin } = useAlerts();
   const [mentionChannel, setMentionChannel] = useState(false);
+  const [message, setMessage] = useState(
+    `@here ${quest?.title} is now available! Check it out here and make a submission`
+  );
   const [publishQuest] = useMutation(PUSH_QUEST_DISCORD_NOTFICATION, {
     onCompleted: () => {
       setSnackbarAlertOpen(true);
@@ -91,8 +101,8 @@ const PublishQuestCardBody = ({ guildDiscordChannels, quest, orgId, existingNoti
         <PublishQuestModal
           onClose={() => setOpenPublishModal(false)}
           channelName={channels?.find((c) => c.value === channel)?.label}
-          mentionChannel={mentionChannel}
-          setMentionChannel={setMentionChannel}
+          setMessage={setMessage}
+          message={message}
           handlePublish={() =>
             publishQuest({
               variables: {
@@ -101,6 +111,7 @@ const PublishQuestCardBody = ({ guildDiscordChannels, quest, orgId, existingNoti
                 orgId,
                 channelId: channel,
                 mentionChannel,
+                message,
               },
             })
           }

--- a/wondrous-bot-admin/src/graphql/mutations/discord.ts
+++ b/wondrous-bot-admin/src/graphql/mutations/discord.ts
@@ -1,8 +1,20 @@
 import { gql } from "@apollo/client";
 
 export const PUSH_QUEST_DISCORD_NOTFICATION = gql`
-  mutation postQuestToDiscord($questId: ID!, $channelId: String!, $orgId: ID!, $mentionChannel: Boolean) {
-    postQuestToDiscord(orgId: $orgId, questId: $questId, channelId: $channelId, mentionChannel: $mentionChannel) {
+  mutation postQuestToDiscord(
+    $questId: ID!
+    $channelId: String!
+    $orgId: ID!
+    $mentionChannel: Boolean
+    $message: String
+  ) {
+    postQuestToDiscord(
+      orgId: $orgId
+      questId: $questId
+      channelId: $channelId
+      mentionChannel: $mentionChannel
+      message: $message
+    ) {
       success
     }
   }


### PR DESCRIPTION
## :pushpin: References

- **Wonder issue:**
- **Related pull-requests:**

## :blue_book: Description

## :movie_camera: Screenshot or Video
<img width="499" alt="Screenshot 2023-06-14 at 09 36 33" src="https://github.com/wondrous-dev/wondrous-frontend/assets/6445805/997073b9-e52f-4754-b275-c825582932ed">

## :cake: Checklist:

- [ ] I self-reviewed my changes
- [ ] My changes follow the style guide: https://creative-earth-33e.notion.site/TT-Wonder-Style-guide-4702a45133374148953bfcaf584120b7
- [ ] I tested my changes in Chrome
