### PR TITLE
fix: settings button is missing on left sidebar

### DIFF
--- a/wondrous-app/components/Common/SidebarCollapseButton/styles.tsx
+++ b/wondrous-app/components/Common/SidebarCollapseButton/styles.tsx
@@ -2,9 +2,7 @@ import { ButtonBase } from '@mui/material';
 import styled from 'styled-components';
 
 export const Wrapper = styled.div`
-  width: 100%;
   display: flex;
-  padding: 24px 14px;
   justify-content: ${({ minimized }) => (minimized ? 'center' : 'flex-end')};
 `;
 

--- a/wondrous-app/components/Common/SidebarEntity/index.tsx
+++ b/wondrous-app/components/Common/SidebarEntity/index.tsx
@@ -1,6 +1,8 @@
+import Box from '@mui/material/Box';
 import CollapseExpandButton from 'components/Common/SidebarCollapseButton';
 import AboutEntity from 'components/Common/SidebarEntityAbout';
 import SidebarEntityList from 'components/Common/SidebarEntityList';
+import SidebarSettingsButton from 'components/Common/SidebarSettingsButton';
 import { ChildrenWrapper, SidebarContent, SidebarWrapper, Wrapper } from 'components/Common/SidebarStyles';
 import useMediaQuery from 'hooks/useMediaQuery';
 import useSideBar from 'hooks/useSideBar';
@@ -14,7 +16,17 @@ const EntitySidebar = ({ children, renderSidebar = null }) => {
       <SidebarWrapper minimized={minimized}>
         {isMobileScreen ? <AboutEntity /> : null}
         <SidebarContent>{renderSidebar ? renderSidebar() : <SidebarEntityList />}</SidebarContent>
-        <CollapseExpandButton />
+        <Box
+          display="flex"
+          flexDirection={minimized ? `column` : `row`}
+          alignItems="center"
+          justifyContent="space-between"
+          padding="24px 14px"
+          gap="24px"
+        >
+          <SidebarSettingsButton />
+          <CollapseExpandButton />
+        </Box>
       </SidebarWrapper>
       <ChildrenWrapper minimized={minimized}>{children}</ChildrenWrapper>
     </Wrapper>

--- a/wondrous-app/components/Common/SidebarEntity/index.tsx
+++ b/wondrous-app/components/Common/SidebarEntity/index.tsx
@@ -23,6 +23,12 @@ const EntitySidebar = ({ children, renderSidebar = null }) => {
           justifyContent="space-between"
           padding="24px 14px"
           gap="24px"
+          width="100%"
+          sx={{
+            '> *': {
+              flexGrow: '1',
+            },
+          }}
         >
           <SidebarSettingsButton />
           <CollapseExpandButton />

--- a/wondrous-app/components/Common/SidebarSettings/index.tsx
+++ b/wondrous-app/components/Common/SidebarSettings/index.tsx
@@ -1,5 +1,6 @@
 import { useLazyQuery } from '@apollo/client';
 import GitHubIcon from '@mui/icons-material/GitHub';
+import Box from '@mui/material/Box';
 import Grid from '@mui/material/Grid';
 import { useMe } from 'components/Auth/withAuth';
 import BackButton from 'components/Common/SidebarBackButton';
@@ -260,7 +261,9 @@ function SettingsWrapper(props) {
               </ListWrapper>
             </ListWrapper>
           </SidebarContent>
-          <CollapseExpandButton />
+          <Box display="flex" width="100%" padding="12px 24px" justifyContent="flex-end">
+            <CollapseExpandButton />
+          </Box>
         </SidebarWrapper>
 
         <ChildrenWrapper minimized={minimized}>

--- a/wondrous-app/components/Common/SidebarSettingsButton/index.tsx
+++ b/wondrous-app/components/Common/SidebarSettingsButton/index.tsx
@@ -3,20 +3,14 @@ import { toolTipStyle } from 'components/Common/SidebarStyles';
 import OrgSettingsIcon from 'components/Icons/OrgSettingsIcon';
 import Tooltip from 'components/Tooltip';
 import Link from 'next/link';
-import { useMemo } from 'react';
 import palette from 'theme/palette';
-import { useGlobalContext } from 'utils/hooks';
+import { useSettingsLink } from 'utils/hooks';
 
 const SidebarSettingsButton = () => {
-  const { pageData, orgsList } = useGlobalContext();
-  const activeOrg = useMemo(
-    () => orgsList.find((org) => org.isActive || org.id === pageData?.pod?.orgId),
-    [orgsList, pageData?.pod?.orgId]
-  );
-  const podId = pageData?.pod?.id;
-  const href = podId ? `/pod/settings/${podId}/general` : `/organization/settings/${activeOrg?.id}/general`;
+  const { href, activePod } = useSettingsLink();
+  if (!href) return null;
   return (
-    <Tooltip style={toolTipStyle} title="Settings" placement="right">
+    <Tooltip style={toolTipStyle} title={activePod ? `Pod Settings` : `Organization Settings`} placement="right">
       <Box
         bgcolor={palette.grey87}
         display="flex"

--- a/wondrous-app/components/Common/SidebarSettingsButton/index.tsx
+++ b/wondrous-app/components/Common/SidebarSettingsButton/index.tsx
@@ -1,0 +1,51 @@
+import Box from '@mui/material/Box';
+import { toolTipStyle } from 'components/Common/SidebarStyles';
+import OrgSettingsIcon from 'components/Icons/OrgSettingsIcon';
+import Tooltip from 'components/Tooltip';
+import Link from 'next/link';
+import { useMemo } from 'react';
+import palette from 'theme/palette';
+import { useGlobalContext } from 'utils/hooks';
+
+const SidebarSettingsButton = () => {
+  const { pageData, orgsList } = useGlobalContext();
+  const activeOrg = useMemo(
+    () => orgsList.find((org) => org.isActive || org.id === pageData?.pod?.orgId),
+    [orgsList, pageData?.pod?.orgId]
+  );
+  const podId = pageData?.pod?.id;
+  const href = podId ? `/pod/settings/${podId}/general` : `/organization/settings/${activeOrg?.id}/general`;
+  return (
+    <Tooltip style={toolTipStyle} title="Settings" placement="right">
+      <Box
+        bgcolor={palette.grey87}
+        display="flex"
+        alignItems="center"
+        justifyContent="center"
+        borderRadius="8px"
+        height="36px"
+        width="36px"
+        sx={{
+          ':hover': {
+            bgcolor: palette.grey78,
+          },
+        }}
+      >
+        <Link
+          href={href}
+          style={{
+            display: 'flex',
+            height: '36px',
+            width: '36px',
+            alignItems: 'center',
+            justifyContent: 'center',
+          }}
+        >
+          <OrgSettingsIcon width="24px" height="100%" />
+        </Link>
+      </Box>
+    </Tooltip>
+  );
+};
+
+export default SidebarSettingsButton;

--- a/wondrous-app/components/Common/SidebarSettingsButton/index.tsx
+++ b/wondrous-app/components/Common/SidebarSettingsButton/index.tsx
@@ -19,6 +19,7 @@ const SidebarSettingsButton = () => {
         borderRadius="8px"
         height="36px"
         width="36px"
+        maxWidth="36px"
         sx={{
           ':hover': {
             bgcolor: palette.grey78,

--- a/wondrous-app/components/WorkspacePicker/index.tsx
+++ b/wondrous-app/components/WorkspacePicker/index.tsx
@@ -1,6 +1,6 @@
 import Popover from '@mui/material/Popover';
 import { OrgProfilePicture, UserProfilePicture } from 'components/Common/ProfilePictureHelpers';
-import { useGlobalContext } from 'utils/hooks';
+import { useGlobalContext, useSettingsLink } from 'utils/hooks';
 
 import { useMutation } from '@apollo/client';
 import { Add } from '@mui/icons-material';
@@ -104,20 +104,8 @@ const LeaveWorkspace = ({ onClose }) => {
 };
 
 const WorkspaceSettings = () => {
-  const router = useRouter();
-  const { pageData, orgsList } = useGlobalContext();
-
-  const activeOrg = useMemo(
-    () => orgsList.find((org) => org.isActive || org.id === pageData?.pod?.orgId),
-    [router.pathname, orgsList]
-  );
-
-  if (!activeOrg) return null;
-
-  const activePod = pageData?.pod;
-
-  const href = activePod ? `/pod/settings/${activePod?.id}/general` : `/organization/settings/${activeOrg?.id}/general`;
-
+  const { href, activePod } = useSettingsLink();
+  if (!href) return null;
   return (
     <UnstyledLink href={href}>
       <HorizontalEntityItem>

--- a/wondrous-app/components/WorkspacePicker/index.tsx
+++ b/wondrous-app/components/WorkspacePicker/index.tsx
@@ -116,9 +116,7 @@ const WorkspaceSettings = () => {
 
   const activePod = pageData?.pod;
 
-  const href = activePod
-    ? `/pod/settings/${activePod?.pod?.id}/general`
-    : `/organization/settings/${activeOrg?.id}/general`;
+  const href = activePod ? `/pod/settings/${activePod?.id}/general` : `/organization/settings/${activeOrg?.id}/general`;
 
   return (
     <UnstyledLink href={href}>

--- a/wondrous-app/utils/hooks.ts
+++ b/wondrous-app/utils/hooks.ts
@@ -499,3 +499,13 @@ export const useHotKeysListener = (key, func, dependencies = []) => {
   const canUseHotkeys = useMemo(() => !PAGES_WITH_NO_HOTKEYS.includes(router.pathname), [router.pathname]);
   return useHotkeys(key, canUseHotkeys ? func : () => {}, [canUseHotkeys, ...dependencies]);
 };
+
+export const useSettingsLink = () => {
+  useRouter();
+  const { pageData, orgsList } = useGlobalContext();
+  const activeOrg = orgsList.find((org) => org.isActive || org.id === pageData?.pod?.orgId);
+  const activePod = pageData?.pod;
+  if (!activeOrg) return { href: null };
+  const href = activePod ? `/pod/settings/${activePod?.id}/general` : `/organization/settings/${activeOrg?.id}/general`;
+  return { href, activePod };
+};


### PR DESCRIPTION
## :pushpin: References

- **Wonder issue:**
- **Related pull-requests:**

## :blue_book: Description

1. fix: settings button is missing on left sidebar
2. fix: when clicking the pod settings on the dropdown, the pod id is undefined

## :movie_camera: Screenshot or Video


https://github.com/wondrous-dev/wondrous-frontend/assets/8164667/cdadf4f2-76a3-48e5-9caf-0ee5ea9364d1


## :cake: Checklist:

- [x] I self-reviewed my changes
- [x] My changes follow the style guide: https://creative-earth-33e.notion.site/TT-Wonder-Style-guide-4702a45133374148953bfcaf584120b7
- [x] I tested my changes in Chrome
