### PR TITLE
feat: add checks so only purchased user can update billing

### DIFF
--- a/wondrous-bot-admin/src/components/Pricing/PricingOptionsListItem.tsx
+++ b/wondrous-bot-admin/src/components/Pricing/PricingOptionsListItem.tsx
@@ -6,6 +6,7 @@ import { BillingIntervalValue } from "./BillingInterval";
 import { PricingOptionsListItemInnerWrapper, PricingOptionsListItemWrapper } from "./styles";
 import { useSubscription } from "utils/hooks";
 import { format } from "date-fns";
+import { useMe } from "components/Auth";
 
 export enum PricingOptionsTitle {
   Basic = "Basic",
@@ -82,7 +83,8 @@ const PricingOptionsListItem = ({
 }: PricingOptionsListItemProps) => {
   const subscription = useSubscription();
   const plan = getPlan(subscription?.tier);
-
+  const user = useMe()?.user;
+  const userPurchasedSubscription = user?.id === subscription?.additionalData?.purchasedUserId;
   const canceled = subscription?.status === "canceled" && subscription?.additionalData?.cancelAtPeriodEnd;
   const willExpire =
     canceled &&
@@ -109,7 +111,9 @@ const PricingOptionsListItem = ({
                   ? yearlyLink
                   : link,
             })}
-          {...(currentPlan && title !== PricingOptionsTitle.Basic && { href: STRIPE_MANAGE_SUBSCRIPTION_LINK })}
+          {...(currentPlan &&
+            title !== PricingOptionsTitle.Basic &&
+            userPurchasedSubscription && { href: STRIPE_MANAGE_SUBSCRIPTION_LINK })}
           target="_blank"
           style={{
             textDecoration: "none",

--- a/wondrous-bot-admin/src/components/Pricing/PricingOptionsListItem.tsx
+++ b/wondrous-bot-admin/src/components/Pricing/PricingOptionsListItem.tsx
@@ -99,18 +99,21 @@ const PricingOptionsListItem = ({
     `(${percentSavings}% off save ${formatCurrency(savings)})`;
   const { childHeight, ref } = useGetChildHeight();
   const currentPlan = plan === title;
+  const canPurchaseNewPlan =
+    !currentPlan &&
+    !expired &&
+    ((subscription && userPurchasedSubscription) || !subscription || title === PricingOptionsTitle.Ecosystem);
   return (
     <PricingOptionsListItemWrapper $colorScheme={colorScheme} $childHeight={childHeight} $willExpire={willExpire}>
       <PricingOptionsListItemInnerWrapper $colorScheme={colorScheme} ref={ref}>
         <a
-          {...(!currentPlan &&
-            !expired && {
-              href:
-                billingInterval === BillingIntervalValue.annual &&
-                (title === PricingOptionsTitle.Hobby || title === PricingOptionsTitle.Premium)
-                  ? yearlyLink
-                  : link,
-            })}
+          {...(canPurchaseNewPlan && {
+            href:
+              billingInterval === BillingIntervalValue.annual &&
+              (title === PricingOptionsTitle.Hobby || title === PricingOptionsTitle.Premium)
+                ? yearlyLink
+                : link,
+          })}
           {...(currentPlan &&
             title !== PricingOptionsTitle.Basic &&
             userPurchasedSubscription && { href: STRIPE_MANAGE_SUBSCRIPTION_LINK })}

--- a/wondrous-bot-admin/src/components/Pricing/index.tsx
+++ b/wondrous-bot-admin/src/components/Pricing/index.tsx
@@ -3,6 +3,9 @@ import { useEffect, useState } from "react";
 import BillingInterval, { BillingIntervalValue } from "./BillingInterval";
 import PricingOptionsList from "./PricingOptionsList";
 import { useNavigate } from "react-router-dom";
+import { BillingInfoContainer, BillingInfoHeaderText } from "components/Settings/Billing/styles";
+import { useSubscription } from "utils/hooks";
+import { useMe } from "components/Auth";
 
 const PricingComponent = () => {
   const navigate = useNavigate();
@@ -11,6 +14,9 @@ const PricingComponent = () => {
     xs: "100%",
     md: "100vh",
   };
+  const subscription = useSubscription();
+  const user = useMe()?.user;
+  const userPurchasedSubscription = user?.id === subscription?.additionalData?.purchasedUserId;
   useEffect(() => {
     if (import.meta.env.VITE_PRODUCTION) {
       navigate("/");
@@ -40,6 +46,36 @@ const PricingComponent = () => {
           Upgrade your community with our premium features
         </Typography>
         <BillingInterval onClick={setBillingInterval} selected={billingInterval} />
+        {subscription && !userPurchasedSubscription && (
+          <Box paddingLeft="16px" paddingRight="16px">
+            <BillingInfoContainer
+              style={{
+                marginBottom: "16px",
+                background: "#2A8D5C",
+                maxWidth: "1200px",
+              }}
+            >
+              <BillingInfoHeaderText
+                style={{
+                  fontSize: "14px",
+                  fontWeight: "500",
+                  color: "white",
+                }}
+              >
+                There's already a subscription associated with this organization! Only the user account who purchased
+                the subscription can update their account. Please contact us our on{" "}
+                <a
+                  style={{ color: "white", textDecoration: "underline" }}
+                  href="https://discord.gg/wonderverse-xyz"
+                  target="_blank"
+                >
+                  Discord
+                </a>{" "}
+                if you want to change this.
+              </BillingInfoHeaderText>
+            </BillingInfoContainer>
+          </Box>
+        )}
       </Grid>
       <Box
         width="100%"

--- a/wondrous-bot-admin/src/components/Settings/Billing/index.tsx
+++ b/wondrous-bot-admin/src/components/Settings/Billing/index.tsx
@@ -11,13 +11,16 @@ import {
   BillingInfoUpdateText,
 } from "./styles";
 import { useSubscription } from "utils/hooks";
+import { useMe } from "components/Auth";
 
 const STRIPE_MANAGE_SUBSCRIPTION_LINK = import.meta.env.VITE_PRODUCTION
   ? "https://billing.stripe.com/p/login/fZefYZfFDdyk6NG8ww"
   : "https://billing.stripe.com/p/login/test_3csbKGfr73hIg2QdQQ";
 const BillingSettings = () => {
   const [billingInterval, setBillingInterval] = useState<BillingIntervalValue>(BillingIntervalValue.monthly);
-
+  const subscription = useSubscription();
+  const user = useMe()?.user;
+  const userPurchasedSubscription = user?.id === subscription?.additionalData?.purchasedUserId;
   return (
     <Grid
       flex="1"
@@ -29,24 +32,47 @@ const BillingSettings = () => {
       <Box display="flex" marginBottom={"32px"} justifyContent="center">
         <BillingInterval onClick={setBillingInterval} selected={billingInterval} />
       </Box>
+      {subscription && !userPurchasedSubscription && (
+        <Box paddingLeft="16px" paddingRight="16px">
+          <BillingInfoContainer
+            style={{
+              marginBottom: "24px",
+            }}
+          >
+            <BillingInfoHeaderText
+              style={{
+                fontSize: "14px",
+                fontWeight: "500",
+              }}
+            >
+              Only the user account who purchased the subscription can update their details! You can however upgrade the
+              subscription.
+            </BillingInfoHeaderText>
+          </BillingInfoContainer>
+        </Box>
+      )}
       <PricingOptionsList billingInterval={billingInterval} settings={true} />
-      <BillingInfoContainer href={STRIPE_MANAGE_SUBSCRIPTION_LINK} target="_blank">
-        <BillingInfoHeader>
-          <BillingInfoHeaderText>Update Billing Information</BillingInfoHeaderText>
-        </BillingInfoHeader>
-        <BillingInfoUpdateText>
-          Have any questions? Shoot us a message in our{" "}
-          <BillingInfoUpdateLink href="https://discord.gg/wonderverse-xyz" target="_blank">
-            Discord
-          </BillingInfoUpdateLink>
-        </BillingInfoUpdateText>
-        <BillingInfoUpdateText>
-          Need to cancel your plan?{" "}
-          <BillingInfoUpdateLink href={STRIPE_MANAGE_SUBSCRIPTION_LINK} target="_blank">
-            Click here
-          </BillingInfoUpdateLink>
-        </BillingInfoUpdateText>
-      </BillingInfoContainer>
+      {subscription && userPurchasedSubscription && (
+        <Box paddingLeft="16px" paddingRight="16px">
+          <BillingInfoContainer href={STRIPE_MANAGE_SUBSCRIPTION_LINK} target="_blank">
+            <BillingInfoHeader>
+              <BillingInfoHeaderText>Update Billing Information</BillingInfoHeaderText>
+            </BillingInfoHeader>
+            <BillingInfoUpdateText>
+              Have any questions? Shoot us a message in our{" "}
+              <BillingInfoUpdateLink href="https://discord.gg/wonderverse-xyz" target="_blank">
+                Discord
+              </BillingInfoUpdateLink>
+            </BillingInfoUpdateText>
+            <BillingInfoUpdateText>
+              Need to cancel your plan?{" "}
+              <BillingInfoUpdateLink href={STRIPE_MANAGE_SUBSCRIPTION_LINK} target="_blank">
+                Click here
+              </BillingInfoUpdateLink>
+            </BillingInfoUpdateText>
+          </BillingInfoContainer>
+        </Box>
+      )}
     </Grid>
   );
 };

--- a/wondrous-bot-admin/src/components/Settings/Billing/index.tsx
+++ b/wondrous-bot-admin/src/components/Settings/Billing/index.tsx
@@ -45,8 +45,12 @@ const BillingSettings = () => {
                 fontWeight: "500",
               }}
             >
-              Only the user account who purchased the subscription can update their details! You can however upgrade the
-              subscription.
+              Only the user account who purchased the subscription for this organization can update their account!
+              Please contact us our on{" "}
+              <a href="https://discord.gg/wonderverse-xyz" target="_blank">
+                Discord
+              </a>{" "}
+              if you want to change this.
             </BillingInfoHeaderText>
           </BillingInfoContainer>
         </Box>

--- a/wondrous-bot-admin/src/graphql/queries/subscription.ts
+++ b/wondrous-bot-admin/src/graphql/queries/subscription.ts
@@ -9,6 +9,7 @@ export const GET_ORG_SUBSCRIPTION = gql`
       additionalData {
         cancelAtPeriodEnd
         currentPeriodEnd
+        purchasedUserId
       }
     }
   }


### PR DESCRIPTION
## :pushpin: References

- **Wonder issue:**
- **Related pull-requests:** https://github.com/wondrous-dev/wondrous-backend/pull/851

## :blue_book: Description
Makes it so that only the user who purchased subscription can edit billing details or cancel a plan.

## :movie_camera: Screenshot or Video

## :cake: Checklist:

- [ ] I self-reviewed my changes
- [ ] My changes follow the style guide: https://creative-earth-33e.notion.site/TT-Wonder-Style-guide-4702a45133374148953bfcaf584120b7
- [ ] I tested my changes in Chrome
