### PR TITLE
feat: add tutorial steps and new onboarding page

### DIFF
--- a/wondrous-bot-admin/src/components/Onboarding/index.tsx
+++ b/wondrous-bot-admin/src/components/Onboarding/index.tsx
@@ -14,6 +14,8 @@ const OnboardingComponent = () => {
   const [orgData, setOrgData] = useState({
     name: "",
     username: "",
+    twitterHandle: "",
+    productLink: "",
   });
 
   const navigate = useNavigate();
@@ -44,18 +46,8 @@ const OnboardingComponent = () => {
       label: "Username",
       value: orgData.username,
       onChange: handleChange,
-      placeholder: "communities",
+      placeholder: "username",
       required: true,
-      onBlur: async () => {
-        if (!orgData.username || !orgData.name) return;
-        try {
-          await validationSchema.validate(orgData, { abortEarly: false });
-        } catch (err) {
-          err.inner.forEach((e) => {
-            setErrors((prev) => ({ ...prev, [e.path]: e.message }));
-          });
-        }
-      },
       padding: "14px 14px 14px 24px",
       startAdornment: (
         <Typography
@@ -71,6 +63,48 @@ const OnboardingComponent = () => {
         </Typography>
       ),
     },
+    {
+      name: "twitterHandle",
+      label: "Twitter Handle",
+      onChange: handleChange,
+      placeholder: "twitter handle",
+      required: true,
+      padding: "14px 14px 14px 24px",
+      startAdornment: (
+        <Typography
+          fontFamily={"Poppins"}
+          fontSize="15px"
+          fontStyle="normal"
+          fontWeight={400}
+          color="black"
+          position="absolute"
+          padding="8px 0px 0px 8px"
+        >
+          @
+        </Typography>
+      ),
+    },
+    {
+      name: "productLink",
+      label: "Product Website",
+      onChange: handleChange,
+      placeholder: "product-link.xyz",
+      required: true,
+      padding: "14px 14px 14px 65px",
+      startAdornment: (
+        <Typography
+          fontFamily={"Poppins"}
+          fontSize="15px"
+          fontStyle="normal"
+          fontWeight={400}
+          color="black"
+          position="absolute"
+          padding="8px 0px 0px 8px"
+        >
+          https://
+        </Typography>
+      ),
+    },
   ];
 
   const handleSubmit = async () => {
@@ -82,6 +116,8 @@ const OnboardingComponent = () => {
             name: orgData.name,
             username: orgData.username,
             cmtyEnabled: true,
+            twitterHandle: orgData.twitterHandle,
+            productLink: orgData.productLink,
           },
         },
       });
@@ -131,7 +167,7 @@ const OnboardingComponent = () => {
             ))}
           </FormControl>
           <SharedSecondaryButton type="button" onClick={handleSubmit}>
-            Launch Community 💖
+            Create Community 💖
           </SharedSecondaryButton>
         </Grid>
       )}

--- a/wondrous-bot-admin/src/components/Onboarding/validator.tsx
+++ b/wondrous-bot-admin/src/components/Onboarding/validator.tsx
@@ -4,6 +4,8 @@ import * as Yup from "yup";
 const FIELDS = {
   NAME: "name",
   USERNAME: "username",
+  TWITTER_HANDLE: "twitterHandle",
+  PRODUCT_LINK: "productLink",
 };
 
 export const useSchema = () => {
@@ -19,8 +21,9 @@ export const useSchema = () => {
         "Usernames should be between 5 and 15 characters long and contain only lowercase letters, numbers, and underscores."
       )
       .test("is-taken", "This username is taken", handleIsOrgUsernameTaken),
+    [FIELDS.TWITTER_HANDLE]: Yup.string().required("Twitter handle is required"),
+    [FIELDS.PRODUCT_LINK]: Yup.string().required("Product link is required"),
   });
-  return validationSchema
-//   return validationSchema.validate(values, { abortEarly: false });
-  
+  return validationSchema;
+  //   return validationSchema.validate(values, { abortEarly: false });
 };

--- a/wondrous-bot-admin/src/components/Shared/Select.tsx
+++ b/wondrous-bot-admin/src/components/Shared/Select.tsx
@@ -15,7 +15,7 @@ const SelectComponent = ({
   const handleChange = (e) => onChange(e.target.value);
 
   return (
-    <Box style={boxStyle}>
+    <Box style={boxStyle} data-tour="tutorial-quest-select">
       <StyledTextFieldSelect
         select
         defaultValue=""

--- a/wondrous-bot-admin/src/components/TutorialComponent/config.tsx
+++ b/wondrous-bot-admin/src/components/TutorialComponent/config.tsx
@@ -31,6 +31,20 @@ export const config = [
     disableInteraction: true,
     steps: [
       {
+        selector: "[data-tour=tutorial-quest-select]",
+        nextButtonTitle: "Next",
+        action: () => {},
+        prevButtonTitle: "Skip",
+        content: () => (
+          <ContentComponent title="Quests">
+            <Typography fontFamily="Poppins" fontWeight={500} fontSize="14px" lineHeight="24px" color="black">
+              You can toggle active and inactive quests here. We created default quests for your to use as templates but
+              they are inactive currently.
+            </Typography>
+          </ContentComponent>
+        ),
+      },
+      {
         selector: "[data-tour=tutorial-quest-card]",
         nextButtonTitle: "Visit Quest",
         action: () => window.scrollTo(0, 0),


### PR DESCRIPTION

<img width="1457" alt="Screenshot 2023-07-22 at 13 26 39" src="https://github.com/wondrous-dev/wondrous-frontend/assets/6445805/e3af19f5-8a22-4d18-b5a4-66f722bed476">
<img width="748" alt="Screenshot 2023-07-22 at 13 32 40" src="https://github.com/wondrous-dev/wondrous-frontend/assets/6445805/e9f5a99d-dd0e-41b2-a055-16f8f45cdc2a">
## :pushpin: References

- **Wonder issue:**
- **Related pull-requests:**

## :blue_book: Description
Adds twitter handle and product link to onboarding so we create active default quests for people
## :movie_camera: Screenshot or Video

## :cake: Checklist:

- [ ] I self-reviewed my changes
- [ ] My changes follow the style guide: https://creative-earth-33e.notion.site/TT-Wonder-Style-guide-4702a45133374148953bfcaf584120b7
- [ ] I tested my changes in Chrome
