### PR TITLE
feat: use discord channel id instead of name

### DIFF
--- a/wondrous-bot-admin/src/components/CreateTemplate/index.tsx
+++ b/wondrous-bot-admin/src/components/CreateTemplate/index.tsx
@@ -69,7 +69,6 @@ const CreateTemplate = ({
       setSteps(transformQuestConfig(getQuestById?.steps));
     }
   }, [getQuestById]);
-
   const [removeQuestStepMedia] = useMutation(REMOVE_QUEST_STEP_MEDIA);
 
   const [isSaving, setIsSaving] = useState(false);
@@ -311,7 +310,7 @@ const CreateTemplate = ({
           step.prompt = next.value?.prompt;
           step["additionalData"] = {
             discordMessageType: next.value?.discordMessageType,
-            discordChannelName: next.value?.discordChannelName?.trim(),
+            discordChannelId: next.value?.discordChannelId,
           };
         } else if (next.type === TYPES.DISCORD_EVENT_ATTENDANCE) {
           step.prompt = next.value?.prompt;

--- a/wondrous-bot-admin/src/graphql/fragments/quest.ts
+++ b/wondrous-bot-admin/src/graphql/fragments/quest.ts
@@ -80,6 +80,7 @@ export const QuestFragment = gql`
       }
       additionalData {
         discordChannelName
+        discordChannelId
         tweetHandle
         tweetLink
         tweetPhrase

--- a/wondrous-bot-admin/src/services/validators/index.tsx
+++ b/wondrous-bot-admin/src/services/validators/index.tsx
@@ -21,7 +21,7 @@ const ALL_TYPES = [
   TYPES.DATA_COLLECTION,
   TYPES.LIKE_YT_VIDEO,
   TYPES.SUBSCRIBE_YT_CHANNEL,
-  TYPES.LINK_CLICK
+  TYPES.LINK_CLICK,
 ];
 
 const sharedValidation = {
@@ -117,7 +117,7 @@ const stepTypes = {
     ...twitterSnapshotSharedValidation,
     additionalData: Yup.object().shape({
       discordMessageType: Yup.string().required("Discord message type is required"),
-      discordChannelName: Yup.string().required("Discord channel id is required"),
+      discordChannelId: Yup.string().required("Discord channel id is required"),
     }),
   }),
   [TYPES.NUMBER]: Yup.object().shape({
@@ -172,7 +172,7 @@ const stepTypes = {
     ...twitterSnapshotSharedValidation,
     additionalData: Yup.object().shape({
       linkClickUrl: Yup.string().required("Link is required").url("Must be a url"),
-    })
+    }),
   }),
   [TYPES.SUBSCRIBE_YT_CHANNEL]: Yup.object().shape({
     additionalData: Yup.object().shape({

--- a/wondrous-bot-admin/src/utils/transformQuestConfig.ts
+++ b/wondrous-bot-admin/src/utils/transformQuestConfig.ts
@@ -99,7 +99,7 @@ type OutputQuestStep = {
       }
     | {
         prompt?: string;
-        discordChannelName: string;
+        discordChannelId: string;
         discordMessageType?: string;
       }
     | {
@@ -210,7 +210,7 @@ export function transformQuestConfig(obj: InputQuestStep[]): OutputQuestStep[] {
     } else if (step.type === TYPES.DISCORD_MESSAGE_IN_CHANNEL) {
       outputStep.value = {
         prompt: step?.prompt,
-        discordChannelName: step?.additionalData?.discordChannelName,
+        discordChannelId: step?.additionalData?.discordChannelId,
         discordMessageType: step?.additionalData?.discordMessageType,
       };
     } else if (step.type === TYPES.DISCORD_EVENT_ATTENDANCE) {


### PR DESCRIPTION

<img width="1073" alt="Screenshot 2023-07-23 at 13 19 59" src="https://github.com/wondrous-dev/wondrous-frontend/assets/6445805/0a2dd836-f35c-4230-9030-b0b55b054eca">
<img width="1108" alt="Screenshot 2023-07-23 at 13 20 02" src="https://github.com/wondrous-dev/wondrous-frontend/assets/6445805/48edf471-3113-466c-a5c0-4719e18def13">
## :pushpin: References

- **Wonder issue:**
- **Related pull-requests:**

## :blue_book: Description
Use a select for Discord channels instead of name
## :movie_camera: Screenshot or Video

## :cake: Checklist:

- [ ] I self-reviewed my changes
- [ ] My changes follow the style guide: https://creative-earth-33e.notion.site/TT-Wonder-Style-guide-4702a45133374148953bfcaf584120b7
- [ ] I tested my changes in Chrome
