### PR TITLE
hide modal if connection exists

### DIFF
--- a/wondrous-bot-admin/src/pages/onboarding/discord/addBotModal.tsx
+++ b/wondrous-bot-admin/src/pages/onboarding/discord/addBotModal.tsx
@@ -1,6 +1,5 @@
 import Modal from "components/Shared/Modal";
-import { ConnectWonderbotDescription, ConnectWonderbotImg, ConnectWonderbotText } from "./styles";
-import AddDiscordImg from "assets/addDiscord.svg";
+import { ConnectWonderbotDescription, ConnectWonderbotText } from "./styles";
 import { SharedSecondaryButton } from "components/Shared/styles";
 import { Box } from "@mui/material";
 import ConnectBotComponent from "components/ConnectBotComponent";


### PR DESCRIPTION
## :pushpin: References

- **Wonder issue:**
- **Related pull-requests:**

## :blue_book: Description

If telegram integration or discord integration exists and the user has already seen the modal then we don't show the connection modal on the second time

## :movie_camera: Screenshot or Video

## :cake: Checklist:

- [ ] I self-reviewed my changes
- [ ] My changes follow the style guide: https://creative-earth-33e.notion.site/TT-Wonder-Style-guide-4702a45133374148953bfcaf584120b7
- [ ] I tested my changes in Chrome
