### PR TITLE
onboarding fixes, flickering fixes on quests page

### DIFF
--- a/wondrous-bot-admin/src/components/CreateTemplate/index.tsx
+++ b/wondrous-bot-admin/src/components/CreateTemplate/index.tsx
@@ -125,45 +125,6 @@ const CreateTemplate = ({
     );
   };
 
-  useEffect(() => {
-    if (!isOpen) return;
-    const newSteps = tourSteps.map((step: any) => {
-      if (step.id === "tutorial-quest-rewards") {
-        return {
-          ...step,
-          handleNextAction: () => {
-            setIsRewardModalOpen(true);
-            setCurrentStep((prev) => prev + 1);
-          },
-        };
-      }
-      if (step.id === "tutorial-add-rewards") {
-        return {
-          ...step,
-          handleNextAction: () => {
-            setIsRewardModalOpen(false);
-            setCurrentStep((prev) => prev + 1);
-          },
-          handlePrevAction: () => {
-            setIsRewardModalOpen(false);
-            setCurrentStep((prev) => prev - 1);
-          },
-        };
-      }
-      if (step.id === "tutorial-activate-quest") {
-        return {
-          ...step,
-          handlePrevAction: () => {
-            setIsRewardModalOpen(true);
-            setCurrentStep((prev) => prev - 1);
-          },
-        };
-      }
-      return step;
-    });
-    setTourSteps(newSteps);
-  }, [isOpen]);
-
   const handleUpdateQuestStepsMedia = async (questId, questSteps, localSteps) => {
     const stepsMedia = await Promise.all(
       localSteps.map(async (step, idx) => {

--- a/wondrous-bot-admin/src/components/Rewards/QuestRewardComponent/index.tsx
+++ b/wondrous-bot-admin/src/components/Rewards/QuestRewardComponent/index.tsx
@@ -14,6 +14,8 @@ import {
 } from "./questUtils";
 import { useAddRewardModalState } from "components/Rewards/utils";
 import { PAYMENT_OPTIONS } from "../constants";
+import { useTour } from "@reactour/tour";
+import { useEffect } from "react";
 
 const QuestRewardComponent = ({
   rewards,
@@ -25,7 +27,49 @@ const QuestRewardComponent = ({
   hasReferralStep: boolean;
 }) => {
   const rewardModalState = useAddRewardModalState();
-  const { setIsRewardModalOpen, isTourOpen, setCurrentStep, resetStates } = rewardModalState;
+  const { setIsRewardModalOpen,resetStates } = rewardModalState;
+
+  const { isOpen: isTourOpen, setCurrentStep, setSteps, steps } = useTour();
+
+  useEffect(() => {
+    if (isTourOpen) {
+      const newSteps = steps.map((step: any) => {
+        if (step.id === "tutorial-quest-rewards") {
+          return {
+            ...step,
+            handleNextAction: () => {
+              setIsRewardModalOpen(true);
+              setCurrentStep((prev) => prev + 1);
+            },
+          };
+        }
+        if (step.id === "tutorial-add-rewards") {
+          return {
+            ...step,
+            handleNextAction: () => {
+              setIsRewardModalOpen(false);
+              setCurrentStep((prev) => prev + 1);
+            },
+            handlePrevAction: () => {
+              setIsRewardModalOpen(false);
+              setCurrentStep((prev) => prev - 1);
+            },
+          };
+        }
+        if (step.id === "tutorial-activate-quest") {
+          return {
+            ...step,
+            handlePrevAction: () => {
+              setIsRewardModalOpen(true);
+              setCurrentStep((prev) => prev - 1);
+            },
+          };
+        }
+        return step;
+      });
+      setSteps(newSteps);
+    }
+  }, [isTourOpen]);
 
   const handleToggleModal = () => {
     resetStates()
@@ -124,6 +168,14 @@ const QuestRewardComponent = ({
   };
   const pointReward = rewards.filter((reward) => reward?.type === "points")[0];
   const otherRewards = rewards.filter((reward) => reward?.type !== "points");
+
+  const handleOpenRewardModal = () => {
+    if(isTourOpen) {
+      setCurrentStep((prev) => prev + 1);
+    }
+    setIsRewardModalOpen(true)
+  }
+
   return (
     <>
       <RewardModal
@@ -154,7 +206,7 @@ const QuestRewardComponent = ({
             }}
           />
           <RewardsComponent rewards={otherRewards} rewardComponents={rewardComponents} />
-          <SharedSecondaryButton onClick={() => setIsRewardModalOpen(true)}>
+          <SharedSecondaryButton onClick={handleOpenRewardModal}>
             {hasReferralStep ? "Add reward per referral" : "Add New Reward"}
           </SharedSecondaryButton>
         </Grid>

--- a/wondrous-bot-admin/src/components/Rewards/utils.tsx
+++ b/wondrous-bot-admin/src/components/Rewards/utils.tsx
@@ -252,46 +252,6 @@ export const useDiscordRoleRewardData = () => {
 
 export const useAddRewardModalState = () => {
   const [isRewardModalOpen, setIsRewardModalOpen] = useState(false);
-  const { isOpen: isTourOpen, setCurrentStep, currentStep, setSteps, steps } = useTour();
-  useEffect(() => {
-    if (isTourOpen) {
-      const newSteps = steps.map((step: any) => {
-        if (step.id === "tutorial-quest-rewards") {
-          return {
-            ...step,
-            handleNextAction: () => {
-              setIsRewardModalOpen(true);
-              setCurrentStep((prev) => prev + 1);
-            },
-          };
-        }
-        if (step.id === "tutorial-add-rewards") {
-          return {
-            ...step,
-            handleNextAction: () => {
-              setIsRewardModalOpen(false);
-              setCurrentStep((prev) => prev + 1);
-            },
-            handlePrevAction: () => {
-              setIsRewardModalOpen(false);
-              setCurrentStep((prev) => prev - 1);
-            },
-          };
-        }
-        if (step.id === "tutorial-activate-quest") {
-          return {
-            ...step,
-            handlePrevAction: () => {
-              setIsRewardModalOpen(true);
-              setCurrentStep((prev) => prev - 1);
-            },
-          };
-        }
-        return step;
-      });
-      setSteps(newSteps);
-    }
-  }, [isTourOpen]);
   const [rewardType, setRewardType] = useState(PAYMENT_OPTIONS.DISCORD_ROLE);
   const [discordRoleReward, setDiscordRoleReward] = useState(null);
   const [paymentMethod, setPaymentMethod] = useState(null);
@@ -369,9 +329,6 @@ export const useAddRewardModalState = () => {
     setAddPaymentMethod,
     poapReward,
     setPoapReward,
-    isTourOpen,
-    setCurrentStep,
-    currentStep,
     cmtyStoreItemReward,
     setCmtyStoreItemReward,
     resetStates,

--- a/wondrous-bot-admin/src/pages/quests/index.tsx
+++ b/wondrous-bot-admin/src/pages/quests/index.tsx
@@ -3,6 +3,7 @@ import { Box } from "@mui/material";
 import { useTour } from "@reactour/tour";
 import { useMe } from "components/Auth";
 import PageHeader from "components/PageHeader";
+import PageSpinner from "components/PageSpinner";
 import { PricingOptionsTitle } from "components/Pricing/PricingOptionsListItem";
 import QuestsList from "components/QuestsList";
 import SelectComponent from "components/Shared/Select";
@@ -13,7 +14,7 @@ import { useNavigate } from "react-router-dom";
 import { getPlan } from "utils/common";
 import { QUEST_STATUSES, TUTORIALS } from "utils/constants";
 import GlobalContext from "utils/context/GlobalContext";
-import { usePaywall, useSubscription, useSubscriptionPaywall } from "utils/hooks";
+import { useSubscription, useSubscriptionPaywall } from "utils/hooks";
 
 const INACTIVE_QUESTS = {
   type: QUEST_STATUSES.INACTIVE,
@@ -42,7 +43,9 @@ const QuestsPage = () => {
   const [statuses, setStatuses] = useState(QUEST_STATUSES.OPEN);
   const { user } = useMe() || {};
   const subscription = useSubscription();
-  const { setPaywall, setPaywallMessage, setCanBeClosed, setOnCancel } = useSubscriptionPaywall();
+  const { setPaywall, setPaywallMessage } = useSubscriptionPaywall();
+  const [isLoading, setIsLoading] = useState(true);
+
   const { data: getOrgQuestStatsData, loading } = useQuery(GET_ORG_QUEST_STATS, {
     notifyOnNetworkStatusChange: true,
     variables: {
@@ -72,7 +75,7 @@ const QuestsPage = () => {
       const quest = data?.getQuestsForOrg[0];
       setMeta(quest?.id);
     }
-    if (!data?.getQuestsForOrg?.length) {
+    if (!data?.getQuestsForOrg?.length && statuses === QUEST_STATUSES.OPEN && isLoading) {
       const variables: any = {
         input: {
           orgId: activeOrg?.id,
@@ -81,8 +84,9 @@ const QuestsPage = () => {
         },
       };
       setStatuses(null);
-      await refetch(variables);
+      return await refetch(variables);
     }
+    setIsLoading(false);
   };
 
   const { data, refetch } = useQuery(GET_QUESTS_FOR_ORG, {
@@ -131,6 +135,8 @@ const QuestsPage = () => {
   }, [data?.getQuestsForOrg]);
 
   const questsLength = useMemo(() => data?.getQuestsForOrg?.length || 0, [data?.getQuestsForOrg?.length]);
+
+  if (isLoading) return <PageSpinner />;
 
   return (
     <>


### PR DESCRIPTION
## :pushpin: References

- **Wonder issue:**
- **Related pull-requests:**

## :blue_book: Description

FIXES: 
1. Onboarding tour
2. Stop flickering for quests page when there are no active quests and we redirect the user to active quests

## :movie_camera: Screenshot or Video

## :cake: Checklist:

- [ ] I self-reviewed my changes
- [ ] My changes follow the style guide: https://creative-earth-33e.notion.site/TT-Wonder-Style-guide-4702a45133374148953bfcaf584120b7
- [ ] I tested my changes in Chrome
