### PR TITLE
feat: add support for messaging multiple discord channels

### DIFF
--- a/wondrous-bot-admin/src/components/AddFormEntity/components/AutocompleteMultipleComponent.tsx
+++ b/wondrous-bot-admin/src/components/AddFormEntity/components/AutocompleteMultipleComponent.tsx
@@ -1,0 +1,226 @@
+import { Autocomplete, Box, Grid, MenuItem, TextField } from "@mui/material";
+import ArrowDropDownIcon from "components/Icons/ArrowDropDown";
+import CheckCircleIcon from "components/Icons/CheckCircle";
+import SearchIcon from "components/Icons/Search";
+import ReferralWarningDialog from "components/Referral/referralWarningDialog";
+import { ListboxComponent } from "components/Shared/FetchMoreListbox";
+import { useState } from "react";
+import { scrollbarStyles } from "components/Shared/styles";
+import { TYPES } from "utils/constants";
+import ErrorField from "components/Shared/ErrorField";
+import { CustomComponentWrapper, MenuItemOptionWrapper, StyledChipTag } from "./styles";
+
+const AutocompleteMultipleComponent = ({
+  options,
+  onChange,
+  value,
+  setSteps = null,
+  order = null,
+  fullWidth = false,
+  autocompletProps = {},
+  inputProps = {},
+  placeholder = "Search",
+  bgColor = "#C1B6F6",
+  listBoxProps = {},
+  disableClearable = true,
+  onClear = null,
+  error = null,
+}) => {
+  const [isOpen, setIsOpen] = useState(false);
+  const handleOpenClose = (status) => () => setIsOpen(() => status);
+  const selectedValue = value;
+  const [openReferralDialog, setOpenReferralDialog] = useState(false);
+  const setReferralStep = () => {
+    setSteps([
+      {
+        type: TYPES.REFERRAL,
+        order: 1,
+        required: true,
+        value: "",
+      },
+    ]);
+  };
+  return (
+    <>
+      <ReferralWarningDialog
+        open={openReferralDialog}
+        onClose={() => setOpenReferralDialog(false)}
+        continueClose={setReferralStep}
+      />
+      <Autocomplete
+        multiple
+        value={value}
+        disableClearable={disableClearable}
+        popupIcon={isOpen ? <SearchIcon /> : <ArrowDropDownIcon />}
+        onOpen={handleOpenClose(true)}
+        onClose={handleOpenClose(false)}
+        onChange={(e, option) => {
+          const newArr = option.map((item) => item?.value);
+          onChange(newArr);
+        }}
+        options={options}
+        renderInput={(params) => {
+          return (
+            <>
+              <TextField
+                {...params}
+                label=""
+                placeholder={placeholder}
+                sx={{
+                  outline: "none",
+                  "& input": {
+                    fontFamily: "Poppins, sans-serif",
+                    fontWeight: "500",
+                    paddingLeft: "8px",
+                  },
+                }}
+                {...inputProps}
+              />
+            </>
+          );
+        }}
+        renderTags={(value, getLabelProps) =>
+          value?.map((option, index) => {
+            const props = getLabelProps({ index });
+            return (
+              <StyledChipTag
+                key={index}
+                deleteIcon={
+                  <div
+                    style={{
+                      marginTop: "-4px",
+                    }}
+                  >
+                    &times;
+                  </div>
+                }
+                onClick={props.onDelete}
+                label={option.label}
+                // background={option.color}
+                variant="outlined"
+                onDelete={props.onDelete}
+              />
+            );
+          })
+        }
+        renderOption={(props, option) => {
+          return (
+            <MenuItem
+              disabled={option.disabled}
+              {...props}
+              {...(option.onClick ? { onClick: option.onClick } : {})}
+              sx={{
+                height: "50px",
+                borderRadius: "6px",
+                padding: "0px",
+                fontWeight: "500",
+                fontFamily: "Poppins, sans-serif",
+                ...((value === option.value || option.isSelected) && {
+                  backgroundColor: "#E4E4E4 !important",
+                }),
+              }}
+            >
+              <MenuItemOptionWrapper container justifyContent="space-between" alignItems="center" padding="0">
+                <Grid container item flex="1" gap="4px">
+                  {option.icon}
+                  {option.label || option.value}
+                </Grid>
+
+                {(option.value === value || option.isSelected) && !option.customComponent && <CheckCircleIcon />}
+                {option.displayCustomOnHover && option.customComponent ? (
+                  <CustomComponentWrapper>{option.customComponent()}</CustomComponentWrapper>
+                ) : null}
+              </MenuItemOptionWrapper>
+            </MenuItem>
+          );
+        }}
+        ListboxProps={{
+          sx: {
+            padding: "0px",
+            paddingLeft: "6px",
+            maxHeight: "300px",
+            overflowY: "auto",
+            "&::-webkit-scrollbar": {
+              WebkitAppearance: "none",
+              background: " #fff",
+              width: "18px",
+            },
+            "&::-webkit-scrollbar-track": {
+              background: "rgba(0, 0, 0, 0.20);",
+              border: "6px solid transparent",
+              backgroundClip: "padding-box",
+              borderRadius: "20px",
+            },
+            "&::-webkit-scrollbar-thumb": {
+              border: "6px solid transparent",
+              background: "#2A8D5C",
+              backgroundClip: "padding-box",
+              borderRadius: "100px",
+            },
+            "& .MuiAutocomplete-option": {
+              padding: "0px",
+              paddingLeft: "8px",
+            },
+            "& .Mui-focused": {
+              outline: "1px solid #000",
+              backgroundColor: "#E4E4E4 !important",
+            },
+            ...scrollbarStyles,
+          },
+          ...listBoxProps,
+        }}
+        slotProps={{
+          paper: {
+            sx: {
+              border: "1px solid #000",
+              marginY: "8px",
+              borderRadius: "6px",
+              "& .MuiAutocomplete-noOptions": {
+                fontWeight: "500",
+                fontFamily: "Poppins, sans-serif",
+              },
+            },
+          },
+        }}
+        sx={{
+          background: bgColor,
+          borderRadius: "6px",
+          padding: "0",
+          minHeight: "50px",
+          width: fullWidth ? "100%" : "380px",
+          "& .MuiInputBase-root.MuiOutlinedInput-root": {
+            "& .MuiOutlinedInput-notchedOutline": {
+              border: "none",
+            },
+            "&:hover .MuiOutlinedInput-notchedOutline": {
+              border: "1px solid #000",
+            },
+            "&:focus-within .MuiOutlinedInput-notchedOutline": {
+              border: "1px solid #000",
+            },
+          },
+          "& .MuiAutocomplete-inputRoot": {
+            outline: "none",
+            borderRadius: "6px",
+            minHeight: "50px",
+            padding: "0px",
+            paddingLeft: "6px",
+            boxSizing: "border-box",
+            "&:focus-visible": {
+              outline: "none",
+            },
+          },
+          "& .MuiAutocomplete-input": {
+            boxSizing: "border-box",
+          },
+          "& .MuiAutocomplete-popupIndicatorOpen": {
+            transform: "none",
+          },
+        }}
+        {...autocompletProps}
+      />
+    </>
+  );
+};
+
+export default AutocompleteMultipleComponent;

--- a/wondrous-bot-admin/src/components/AddFormEntity/components/DiscordComponent.tsx
+++ b/wondrous-bot-admin/src/components/AddFormEntity/components/DiscordComponent.tsx
@@ -19,6 +19,7 @@ import { ErrorText } from "components/Shared/styles";
 import AutocompleteOptionsComponent from "./AutocompleteComponent";
 import ErrorField from "components/Shared/ErrorField";
 import InfoLabel from "components/CreateTemplate/InfoLabel";
+import AutocompleteMultipleComponent from "./AutocompleteMultipleComponent";
 
 const TextInputStyle = {
   width: "50%",
@@ -60,17 +61,28 @@ const DiscordChannelMessage = ({ handleOnChange, value, error }) => {
     label: channel.name,
     value: channel.id,
   }));
+  const defaultSelectedChannels = channels?.filter((channel) => {
+    if (value?.discordChannelIds) {
+      return value?.discordChannelIds?.includes(channel.value);
+    }
+    return false;
+  });
+  const defaultSelectedChannel = channels?.filter((channel) => {
+    if (value?.discordChannelIds) {
+      return channel.value === value?.discordChannelId;
+    }
+    return false;
+  });
   return (
     <>
       <Label>Ask members to message a particular channel</Label>
-      <AutocompleteOptionsComponent 
-        value={value?.discordChannelId || ""}
-        onChange={(value) => handleOnChange("discordChannelId", value)}
-        options={channels}
+      <AutocompleteMultipleComponent
+        value={defaultSelectedChannels || (value?.discordChannelId ? [defaultSelectedChannel] : [])}
+        onChange={(value) => handleOnChange("discordChannelIds", value)}
+        options={channels || []}
         placeholder="Select a channel"
-        
       />
-      {error?.discordChannelId ? <ErrorField errorText={error?.discordChannelId}/> : null}
+      {error?.discordChannelIds ? <ErrorField errorText={error?.discordChannelId} /> : null}
 
       {/* <Label>Select message type</Label>
       <SelectComponent
@@ -153,9 +165,9 @@ const DiscordJoinCommunityCall = ({ handleOnChange, value, error }) => {
 
   return (
     <>
-      <div style={{display: 'flex'}}>
-      <Label>Select Event </Label>
-      <InfoLabel title={'First create the event on Discord, refresh the page'}/>
+      <div style={{ display: "flex" }}>
+        <Label>Select Event </Label>
+        <InfoLabel title={"First create the event on Discord, refresh the page"} />
       </div>
       {options && (
         <SelectComponent

--- a/wondrous-bot-admin/src/components/AddFormEntity/components/styles.tsx
+++ b/wondrous-bot-admin/src/components/AddFormEntity/components/styles.tsx
@@ -1,7 +1,22 @@
 import { InputUnstyled } from "@mui/base";
-import { Box, Grid, Typography } from "@mui/material";
+import { Box, Chip, Grid, Typography } from "@mui/material";
 import styled from "styled-components";
 
+export const StyledChipTag = styled(Chip)`
+  && {
+    background: rgba(0, 0, 0, 0.1);
+    border: 0;
+    border-radius: 4px;
+    display: flex;
+    align-items: center;
+    margin-left: 8px;
+    > span {
+      font-weight: 500;
+      font-size: 16px;
+      font-family: "Poppins";
+    }
+  }
+`;
 export const CustomTextField = styled(InputUnstyled)`
   width: 100%;
   && {

--- a/wondrous-bot-admin/src/components/CreateTemplate/helpers.ts
+++ b/wondrous-bot-admin/src/components/CreateTemplate/helpers.ts
@@ -70,6 +70,7 @@ const processSteps = (steps) =>
       step["additionalData"] = {
         discordMessageType: next.value?.discordMessageType,
         discordChannelId: next.value?.discordChannelId,
+        discordChannelIds: next.value?.discordChannelIds,
       };
     } else if (next.type === TYPES.DISCORD_EVENT_ATTENDANCE) {
       step.prompt = next.value?.prompt;

--- a/wondrous-bot-admin/src/graphql/fragments/quest.ts
+++ b/wondrous-bot-admin/src/graphql/fragments/quest.ts
@@ -28,7 +28,6 @@ export const QuestListFragment = gql`
   }
 `;
 
-
 export const MinimalQuestFragment = gql`
   fragment MinimalQuestFragment on Quest {
     id
@@ -82,7 +81,6 @@ export const MinimalQuestFragment = gql`
     }
   }
 `;
-
 
 export const QuestFragment = gql`
   fragment QuestFragment on Quest {
@@ -218,6 +216,7 @@ export const QuestFragment = gql`
       additionalData {
         discordChannelName
         discordChannelId
+        discordChannelIds
         tweetHandle
         tweetLink
         tweetPhrase

--- a/wondrous-bot-admin/src/graphql/queries/quest.ts
+++ b/wondrous-bot-admin/src/graphql/queries/quest.ts
@@ -239,6 +239,7 @@ export const EXPORT_QUEST_SUBMISSIONS = gql`
         additionalData {
           discordChannelName
           discordChannelId
+          discordChannelIds
           tweetHandle
           tweetLink
           tweetPhrase

--- a/wondrous-bot-admin/src/graphql/queries/questSubmission.ts
+++ b/wondrous-bot-admin/src/graphql/queries/questSubmission.ts
@@ -53,8 +53,22 @@ export const GET_USER_QUEST_SUBMISSION_ANALYTICS = gql`
 `;
 
 export const GET_USER_QUEST_SUBMISSIONS = gql`
-  query getUserQuestSubmissions($cmtyUserId: ID!, $orgId: ID!, $limit: Int, $offset: Int, $questId: String, $status: String) {
-    getUserQuestSubmissions(cmtyUserId: $cmtyUserId, orgId: $orgId, limit: $limit, offset: $offset, questId: $questId, status: $status) {
+  query getUserQuestSubmissions(
+    $cmtyUserId: ID!
+    $orgId: ID!
+    $limit: Int
+    $offset: Int
+    $questId: String
+    $status: String
+  ) {
+    getUserQuestSubmissions(
+      cmtyUserId: $cmtyUserId
+      orgId: $orgId
+      limit: $limit
+      offset: $offset
+      questId: $questId
+      status: $status
+    ) {
       id
       createdAt
       orgId
@@ -97,6 +111,7 @@ export const GET_USER_QUEST_SUBMISSIONS = gql`
           additionalData {
             discordChannelName
             discordChannelId
+            discordChannelIds
             tweetHandle
             tweetLink
             tweetPhrase
@@ -127,7 +142,6 @@ export const GET_USER_QUEST_SUBMISSIONS = gql`
     }
   }
 `;
-
 
 export const GET_ONBOARDING_QUEST_SUBMISSIONS = gql`
   query getQuestSubmissionsOnboarding($cmtyUserId: ID!, $orgId: ID!, $limit: Int, $offset: Int) {
@@ -174,6 +188,7 @@ export const GET_ONBOARDING_QUEST_SUBMISSIONS = gql`
           additionalData {
             discordChannelName
             discordChannelId
+            discordChannelIds
             tweetHandle
             tweetLink
             tweetPhrase

--- a/wondrous-bot-admin/src/services/validators/index.tsx
+++ b/wondrous-bot-admin/src/services/validators/index.tsx
@@ -1,8 +1,7 @@
-
 export * from "./questValidator";
 export * from "./storeValidator";
 export * from "./customValidation";
-export * from './referralValidator';
+export * from "./referralValidator";
 
 import { ERRORS, STORE_ITEM_TYPES, TYPES } from "utils/constants";
 import * as Yup from "yup";
@@ -40,7 +39,12 @@ const ALL_TYPES = [
   TYPES.CONNECT_WALLET,
 ];
 
-export const STORE_TYPES = [STORE_ITEM_TYPES.EXTERNAL_SHOP, STORE_ITEM_TYPES.DISCORD_ROLE, STORE_ITEM_TYPES.NFT, STORE_ITEM_TYPES.TOKEN];
+export const STORE_TYPES = [
+  STORE_ITEM_TYPES.EXTERNAL_SHOP,
+  STORE_ITEM_TYPES.DISCORD_ROLE,
+  STORE_ITEM_TYPES.NFT,
+  STORE_ITEM_TYPES.TOKEN,
+];
 
 const sharedValidation = {
   type: Yup.string().required("Type is required").oneOf(ALL_TYPES, "Type is not valid"),
@@ -106,13 +110,13 @@ const stepTypes = {
     ...twitterSnapshotSharedValidation,
     additionalData: Yup.object().shape({
       tweetHandle: Yup.string()
-      .matches(twitterHandleRegex, 'Invalid Twitter handle')
-      .required("Tweet handle is required")
-      .test(
-        'is-not-url', 
-        'Tweet handle must not be a URL', 
-        value => !/^(https?:\/\/)?([\w-]+\.)+[\w-]+(\/[\w-]*)*\/?$/.test(value)
-      )
+        .matches(twitterHandleRegex, "Invalid Twitter handle")
+        .required("Tweet handle is required")
+        .test(
+          "is-not-url",
+          "Tweet handle must not be a URL",
+          (value) => !/^(https?:\/\/)?([\w-]+\.)+[\w-]+(\/[\w-]*)*\/?$/.test(value)
+        ),
     }),
   }),
   [TYPES.TWEET_WITH_PHRASE]: Yup.object().shape({
@@ -144,7 +148,7 @@ const stepTypes = {
   [TYPES.DISCORD_MESSAGE_IN_CHANNEL]: Yup.object().shape({
     ...twitterSnapshotSharedValidation,
     additionalData: Yup.object().shape({
-      discordChannelId: Yup.string().required("Discord channel is required"),
+      discordChannelIds: Yup.array().of(Yup.string()).required("At least one Discord channel is required"),
     }),
   }),
   [TYPES.NUMBER]: Yup.object().shape({
@@ -304,4 +308,3 @@ export const storeItemValidator = async (body) => {
     abortEarly: false,
   });
 };
-

--- a/wondrous-bot-admin/src/services/validators/questValidator.tsx
+++ b/wondrous-bot-admin/src/services/validators/questValidator.tsx
@@ -126,7 +126,7 @@ const stepTypes = {
   [TYPES.DISCORD_MESSAGE_IN_CHANNEL]: Yup.object().shape({
     ...twitterSnapshotSharedValidation,
     additionalData: Yup.object().shape({
-      discordChannelId: Yup.string().required("Discord channel is required"),
+      discordChannelIds: Yup.array().of(Yup.string()).required("At least one Discord channel is required"),
     }),
   }),
   [TYPES.NUMBER]: Yup.object().shape({

--- a/wondrous-bot-admin/src/utils/transformQuestConfig.ts
+++ b/wondrous-bot-admin/src/utils/transformQuestConfig.ts
@@ -27,6 +27,7 @@ type InputQuestStep = {
     snapshotSpaceLink?: string;
     snapshotVoteTimes?: number;
     discordChannelId?: string;
+    discordChannelIds?: string[];
     discordChannelName?: string;
     discordMessageType?: string;
     dataCollectionType?: string;
@@ -103,7 +104,8 @@ type OutputQuestStep = {
       }
     | {
         prompt?: string;
-        discordChannelId: string;
+        discordChannelId?: string;
+        discordChannelIds?: string[];
         discordMessageType?: string;
       }
     | {
@@ -229,6 +231,7 @@ export function transformQuestConfig(obj: InputQuestStep[]): OutputQuestStep[] {
       outputStep.value = {
         prompt: step?.prompt,
         discordChannelId: step?.additionalData?.discordChannelId,
+        discordChannelIds: step?.additionalData?.discordChannelIds,
         discordMessageType: step?.additionalData?.discordMessageType,
       };
     } else if (step.type === TYPES.DISCORD_EVENT_ATTENDANCE) {


### PR DESCRIPTION

## :pushpin: References

- **Wonder issue:**
- **Related pull-requests:**

## :blue_book: Description
Adding support for verifying message sent in channel a, b, etc. Used for Apeiron request.

## :movie_camera: Screenshot or Video

<img width="885" alt="Screenshot 2024-01-04 at 15 01 37" src="https://github.com/wondrous-dev/wondrous-frontend/assets/6445805/5e204b12-e7b9-4318-b4b6-8011eb094799">
## :cake: Checklist:

- [ ] I self-reviewed my changes
- [ ] My changes follow the style guide: https://creative-earth-33e.notion.site/TT-Wonder-Style-guide-4702a45133374148953bfcaf584120b7
- [ ] I tested my changes in Chrome
