### PR TITLE
Add max prompt length

### DIFF
--- a/wondrous-bot-admin/src/components/AddFormEntity/components/DataCollection/index.tsx
+++ b/wondrous-bot-admin/src/components/AddFormEntity/components/DataCollection/index.tsx
@@ -9,6 +9,7 @@ import InterestsComponent from "./InterestsComponent";
 import LocationComponent from "./Location";
 import Skills from "./Skills";
 import { ErrorText } from "components/Shared/styles";
+import { Box } from "@mui/material";
 
 const OPTIONS = [
   {
@@ -79,7 +80,12 @@ const DataCollectionComponent = (props) => {
         }}
       >
         <Label>Select what you want to collect</Label>
-        <SelectComponent onChange={handleTypeChange} value={dataCollectionType} options={OPTIONS} error={error?.additionalData?.dataCollectionType}/>
+        <SelectComponent
+          onChange={handleTypeChange}
+          value={dataCollectionType}
+          options={OPTIONS}
+          error={error?.additionalData?.dataCollectionType}
+        />
       </Grid>
       <Grid
         item
@@ -95,10 +101,17 @@ const DataCollectionComponent = (props) => {
         <TextField
           placeholder="Enter prompt here"
           value={prompt || ""}
-          onChange={(value) => handleOnChange("prompt", value)}
+          onChange={(value) => {
+            if (value.length <= 256) {
+              handleOnChange("prompt", value);
+            }
+          }}
           multiline={false}
           error={error?.prompt}
         />
+        <Box fontSize="13px" color="#2A8D5C" fontWeight="500" marginTop="-8px">
+          {prompt.length} / 256
+        </Box>
       </Grid>
       {dataCollectionType === DATA_COLLECTION_TYPES.INTERESTS ? (
         <InterestsComponent

--- a/wondrous-bot-admin/src/components/AddFormEntity/components/DataCollection/index.tsx
+++ b/wondrous-bot-admin/src/components/AddFormEntity/components/DataCollection/index.tsx
@@ -110,7 +110,7 @@ const DataCollectionComponent = (props) => {
           error={error?.prompt}
         />
         <Box fontSize="13px" color="#2A8D5C" fontWeight="500" marginTop="-8px">
-          {prompt.length} / 256
+          {prompt?.length} / 256
         </Box>
       </Grid>
       {dataCollectionType === DATA_COLLECTION_TYPES.INTERESTS ? (

--- a/wondrous-bot-admin/src/components/AddFormEntity/components/DiscordComponent.tsx
+++ b/wondrous-bot-admin/src/components/AddFormEntity/components/DiscordComponent.tsx
@@ -259,7 +259,7 @@ const DiscordComponent = ({ onChange, value, stepType, error }) => {
             error={error?.prompt}
           />
           <Box fontSize="13px" color="#2A8D5C" fontWeight="500" marginTop="-8px">
-            {prompt.length} / 256
+            {prompt?.length} / 256
           </Box>
         </Grid>
         {getDiscordComponent(stepType, handleOnChange, value, error)}

--- a/wondrous-bot-admin/src/components/AddFormEntity/components/DiscordComponent.tsx
+++ b/wondrous-bot-admin/src/components/AddFormEntity/components/DiscordComponent.tsx
@@ -1,5 +1,5 @@
 import React, { useContext, useEffect } from "react";
-import { Grid } from "@mui/material";
+import { Box, Grid } from "@mui/material";
 import apollo from "services/apollo";
 import { Label } from "./styles";
 import TextField from "../../Shared/TextField";
@@ -250,10 +250,17 @@ const DiscordComponent = ({ onChange, value, stepType, error }) => {
           <TextField
             placeholder="Enter prompt here (Ex. Join our weekly community call for a minimum of 10 minutes)"
             value={prompt || ""}
-            onChange={(value) => handleOnChange("prompt", value)}
+            onChange={(value) => {
+              if (value?.length <= 256) {
+                handleOnChange("prompt", value);
+              }
+            }}
             multiline={false}
             error={error?.prompt}
           />
+          <Box fontSize="13px" color="#2A8D5C" fontWeight="500" marginTop="-8px">
+            {prompt.length} / 256
+          </Box>
         </Grid>
         {getDiscordComponent(stepType, handleOnChange, value, error)}
       </Grid>

--- a/wondrous-bot-admin/src/components/AddFormEntity/components/GitcoinPassportComponent.tsx
+++ b/wondrous-bot-admin/src/components/AddFormEntity/components/GitcoinPassportComponent.tsx
@@ -1,4 +1,4 @@
-import { Grid, Typography } from "@mui/material";
+import { Box, Grid, Typography } from "@mui/material";
 import { IndexContainer, Label } from "./styles";
 import TextField from "../../Shared/TextField";
 import { TYPES } from "utils/constants";
@@ -13,10 +13,17 @@ const GitcoinPassportScore = ({ handleOnChange, value, errors }) => (
     <TextField
       placeholder="Enter prompt here"
       value={value?.prompt || ""}
-      onChange={(value) => handleOnChange("prompt", value)}
+      onChange={(value) => {
+        if (value.length <= 256) {
+          handleOnChange("prompt", value);
+        }
+      }}
       multiline={false}
       error={errors?.prompt}
     />
+    <Box fontSize="13px" color="#2A8D5C" fontWeight="500" marginTop="-8px">
+      {value?.prompt?.length} / 256
+    </Box>
     <Label>Verify that a user's Gitcoin Passport Score is above this threshold</Label>
     <TextField
       placeholder="Please enter the minimum score threshold"

--- a/wondrous-bot-admin/src/components/AddFormEntity/components/LinkClickComponent.tsx
+++ b/wondrous-bot-admin/src/components/AddFormEntity/components/LinkClickComponent.tsx
@@ -1,4 +1,4 @@
-import { Grid, Typography } from "@mui/material";
+import { Box, Grid, Typography } from "@mui/material";
 import { IndexContainer, Label } from "./styles";
 import TextField from "../../Shared/TextField";
 import { TYPES } from "utils/constants";
@@ -9,10 +9,17 @@ const YoutubeLikeText = ({ handleOnChange, value, error }) => (
     <TextField
       placeholder="Enter prompt here (Eg. Go to this link to check out our mission + vision)"
       value={value?.prompt || ""}
-      onChange={(value) => handleOnChange("prompt", value)}
+      onChange={(value) => {
+        if (value.length <= 256) {
+          handleOnChange("prompt", value);
+        }
+      }}
       multiline={false}
       error={error?.prompt}
     />
+    <Box fontSize="13px" color="#2A8D5C" fontWeight="500" marginTop="-8px">
+      {value?.prompt?.length} / 256
+    </Box>
     <Label>Link to visit</Label>
     <TextField
       placeholder="Please enter the url"

--- a/wondrous-bot-admin/src/components/AddFormEntity/components/QuizComponent.tsx
+++ b/wondrous-bot-admin/src/components/AddFormEntity/components/QuizComponent.tsx
@@ -154,10 +154,17 @@ const QuizComponent = ({ onChange, value, stepType, error }) => {
           <TextField
             placeholder="Enter question here"
             value={question || ""}
-            onChange={(value) => handleOnChange("question", value)}
+            onChange={(value) => {
+              if (value.length <= 256) {
+                handleOnChange("question", value);
+              }
+            }}
             multiline={false}
             error={error?.prompt}
           />
+          <Box fontSize="13px" color="#2A8D5C" fontWeight="500" marginTop="-8px">
+            {question.length} / 256
+          </Box>
         </Grid>
         <Grid item gap="14px" display="flex" flexDirection="column">
           <Typography fontFamily="Poppins" fontWeight={600} fontSize="13px" lineHeight="15px" color="#626262">

--- a/wondrous-bot-admin/src/components/AddFormEntity/components/QuizComponent.tsx
+++ b/wondrous-bot-admin/src/components/AddFormEntity/components/QuizComponent.tsx
@@ -163,7 +163,7 @@ const QuizComponent = ({ onChange, value, stepType, error }) => {
             error={error?.prompt}
           />
           <Box fontSize="13px" color="#2A8D5C" fontWeight="500" marginTop="-8px">
-            {question.length} / 256
+            {question?.length} / 256
           </Box>
         </Grid>
         <Grid item gap="14px" display="flex" flexDirection="column">


### PR DESCRIPTION

<img width="876" alt="Screenshot 2024-02-15 at 06 47 49" src="https://github.com/wondrous-dev/wondrous-frontend/assets/6445805/e5e2700f-e666-4ae2-8920-bab23e7f7a14">
## :pushpin: References

- **Wonder issue:**
- **Related pull-requests:**

## :blue_book: Description

## :movie_camera: Screenshot or Video
<img width="876" alt="Screenshot 2024-02-15 at 06 47 49" src="https://github.com/wondrous-dev/wondrous-frontend/assets/6445805/3b48a125-73b5-4c62-9346-f38acecf151e">
## :cake: Checklist:

- [ ] I self-reviewed my changes
- [ ] My changes follow the style guide: https://creative-earth-33e.notion.site/TT-Wonder-Style-guide-4702a45133374148953bfcaf584120b7
- [ ] I tested my changes in Chrome

